### PR TITLE
Fix logo styling for admin page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,7 +24,13 @@ button.bg-dark:focus {
 
 .dlimg {
     max-height: 70px;
-    margin-right: 6px;
+    margin-right: 20px;
+}
+
+@media only screen and (max-width: 1024px) {
+    .dlimg{
+        margin-left: 25px;
+    }
 }
 
 .gimg {

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -489,8 +489,8 @@ mark,
 
 
 .dlimg {
-  width: 60px;         /* or any size you want */
-  height: 60px;        /* must match width for a perfect circle */
+  width: 36px;         /* or any size you want */
+  height: 36px;        /* must match width for a perfect circle */
   border-radius: 50%;   /* makes it circular */
   object-fit: cover;    /* keeps the image from stretching */
 }


### PR DESCRIPTION
## **Pull Request**

### **Description:**
This PR corrects the admin page logo's proportions and alignment for the desktop layout, while adding media queries to ensure the spacing remains intact on smaller screens. This PR closes #30.

### **Changes:**
* **Desktop:** Decreased the admin page logo's height and width, and increased the right margin for proper alignment.
* **Mobile & Tablet:** Added a left margin via media queries to maintain balanced spacing on smaller devices.

### **Screenshots:**
<img width="1366" height="768" alt="Screenshot from 2026-02-16 20-53-49" src="https://github.com/user-attachments/assets/430b4d1d-ba1d-4e5d-8306-a9325c7b81d3" />
<img width="500" height="678" alt="Screenshot from 2026-02-16 20-57-34" src="https://github.com/user-attachments/assets/4f0162ba-03bc-4a12-a802-069edaa84c31" />