### PR TITLE
closes #27

### DIFF
--- a/frontend/src/admin/AdminAlumni.jsx
+++ b/frontend/src/admin/AdminAlumni.jsx
@@ -13,7 +13,10 @@ const AdminAlumni = () => {
   useEffect(() => {
     axios.get(`${baseUrl}/alumni`, { withCredentials: true })
       .then((res) => {
-        setAlumni(res.data);
+        const safeAlumni = Array.isArray(res.data)
+          ? res.data.filter((item) => item && typeof item === 'object')
+          : [];
+        setAlumni(safeAlumni);
         // console.log(res.data);
       })
       .catch((err) => console.log(err));
@@ -80,7 +83,7 @@ const AdminAlumni = () => {
                           {/* $alumni = $conn->query("SELECT a.*,c.course,Concat(a.lastname,', ',a.firstname,' ',a.middlename) as name from alumnus_bio a inner join courses c on c.id = a.course_id order by Concat(a.lastname,', ',a.firstname,' ',a.middlename) asc"); */}
                           {alumni.map((a, index) => (
 
-                            <tr key={index}>
+                            <tr key={a._id || a.id || index}>
                               <td className="text-center">{index + 1}</td>
                               <td className="text-center">
                                 <div className="avatar">
@@ -94,7 +97,7 @@ const AdminAlumni = () => {
                                 </div>
                               </td>
                               <td className="">
-                                <p> <b>{a.name}</b></p>
+                                <p> <b>{a.name || 'N/A'}</b></p>
                               </td>
                               <td className="">
                                 <p> <b>{a.alumnus_bio?.course?.course || a.alumnus_bio?.course?.name || 'N/A'}</b></p>

--- a/frontend/src/admin/AdminJobApplications.jsx
+++ b/frontend/src/admin/AdminJobApplications.jsx
@@ -17,7 +17,10 @@ const AdminJobApplications = () => {
     try {
       const res = await axios.get(`${baseUrl}/jobs`, { withCredentials: true });
       // Filter only jobs that have applicants
-      const jobsWithApplicants = res.data.filter(job => job.applicants && job.applicants.length > 0);
+      const safeJobs = Array.isArray(res.data)
+        ? res.data.filter((job) => job && typeof job === 'object')
+        : [];
+      const jobsWithApplicants = safeJobs.filter((job) => job.applicants && job.applicants.length > 0);
       setJobs(jobsWithApplicants);
       setLoading(false);
     } catch (err) {

--- a/frontend/src/admin/AdminJobs.jsx
+++ b/frontend/src/admin/AdminJobs.jsx
@@ -26,8 +26,10 @@ const AdminJobs = () => {
     useEffect(() => {
         axios.get(`${baseUrl}/jobs`, { withCredentials: true })
             .then((res) => {
-                console.log(res.data);
-                setJobs(res.data);
+                const safeJobs = Array.isArray(res.data)
+                    ? res.data.filter((job) => job && typeof job === 'object')
+                    : [];
+                setJobs(safeJobs);
             })
             .catch((err) => console.log(err));
     }, []);
@@ -83,11 +85,11 @@ const AdminJobs = () => {
                                             <tbody>
                                                 {jobs.length > 0 ? <>
                                                     {jobs.map((job, index) => (
-                                                        <tr key={index}>
+                                                        <tr key={job._id || job.id || index}>
                                                             <td className="text-center">{index + 1}</td>
-                                                            <td className=""><b>{job.company}</b></td>
-                                                            <td className=""><b>{job.job_title}</b></td>
-                                                            <td className=""><b>{job.user.name}</b></td>
+                                                            <td className=""><b>{job.company || 'Unknown Company'}</b></td>
+                                                            <td className=""><b>{job.job_title || 'Untitled Job'}</b></td>
+                                                            <td className=""><b>{job.user?.name || 'Unknown'}</b></td>
                                                             <td className="text-center justify-content-center border-0 d-flex gap-1">
                                                                 <button className="btn btn-sm btn-outline-primary view_career" type="button" onClick={() => openModal(job)}>View</button>
                                                                 <Link to="/dashboard/jobs/manage" state={{ action: "edit", data: job }} className="btn btn-sm btn-outline-primary edit_career" >Edit</Link>

--- a/frontend/src/admin/AdminUsers.jsx
+++ b/frontend/src/admin/AdminUsers.jsx
@@ -11,8 +11,10 @@ const AdminUsers = () => {
   useEffect(() => {
     axios.get(`${baseUrl}/users`, { withCredentials: true })
       .then((res) => {
-        setUsers(res.data);
-        console.log(users);
+        const safeUsers = Array.isArray(res.data)
+          ? res.data.filter((user) => user && typeof user === 'object')
+          : [];
+        setUsers(safeUsers);
       })
       .catch((err) => console.log(err));
   }, []);
@@ -55,11 +57,11 @@ const AdminUsers = () => {
                   </thead>
                   <tbody>
                     {users.map((user, index) => (
-                      <tr key={index}>
+                      <tr key={user._id || user.id || index}>
                         <td className="text-center">{index + 1}</td>
-                        <td>{user.name}</td>
-                        <td>{user.email}</td>
-                        <td>{user.type}</td>
+                        <td>{user.name || 'N/A'}</td>
+                        <td>{user.email || 'N/A'}</td>
+                        <td>{user.type || 'N/A'}</td>
                         <td className="text-center">
                           <Link to="/dashboard/users/manage" state={{ status: "edit", data: user }} className="btn btn-primary btn-sm mr-2">
                             <FaEdit /> Edit

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,18 +1,19 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import logo from "../assets/uploads/logo.png"
 import { baseUrl } from '../utils/globalurl';
 
 const About = () => {
-  const [system, setSystem] = useState([]);
+  const [system, setSystem] = useState(null);
 
 
   useEffect(() => {
     // axios.get('http://localhost:3000/auth/settings')
     axios.get(`${baseUrl}/settings`)
       .then((res) => {
-        setSystem(res.data);
-        console.log(res.data);
+        const settings = Array.isArray(res.data)
+          ? res.data.find((item) => item && typeof item === 'object')
+          : res.data;
+        setSystem(settings || null);
       })
       .catch((err) => console.log(err));
   }, []);
@@ -37,15 +38,12 @@ const About = () => {
   </div>
 </header>
 
-
-
-
-      {system.length > 0 && (
+      {system && (
         <section className="page-section">
           <div className="container">
-            <h2 className='text-center'>{system[0].name}</h2>
+            <h2 className='text-center'>{system.name || 'Alumni Management System'}</h2>
             <br />
-            <p dangerouslySetInnerHTML={{ __html: system[0].about_content }}></p>
+            <p dangerouslySetInnerHTML={{ __html: system.about_content || '' }}></p>
           </div>
         </section>
       )}

--- a/frontend/src/components/AlumniList.jsx
+++ b/frontend/src/components/AlumniList.jsx
@@ -17,7 +17,12 @@ const AlumniList = () => {
   useEffect(() => {
     axios
       .get(`${baseUrl}/alumni`)
-      .then((res) => setAlumniList(res.data))
+      .then((res) => {
+        const safeAlumni = Array.isArray(res.data)
+          ? res.data.filter((item) => item && typeof item === "object")
+          : [];
+        setAlumniList(safeAlumni);
+      })
       .catch((err) => console.log(err));
   }, []);
 
@@ -30,20 +35,20 @@ const AlumniList = () => {
 
     return alumniList.filter(
       (list) =>
-        list.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        list.alumnus_bio?.course?.course
+        list?.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        list?.alumnus_bio?.course?.course
           ?.toLowerCase()
           .includes(searchQuery.toLowerCase()) ||
-        list.alumnus_bio?.batch?.toString().includes(searchQuery),
+        list?.alumnus_bio?.batch?.toString().includes(searchQuery),
     );
   }, [searchQuery, alumniList]);
 
   const totalAlumni = alumniList.length;
   const verifiedCount = alumniList.filter(
-    (a) => a.alumnus_bio?.status === 1,
+    (a) => a?.alumnus_bio?.status === 1,
   ).length;
   const unverifiedCount = alumniList.filter(
-    (a) => a.alumnus_bio?.status === 0,
+    (a) => a?.alumnus_bio?.status === 0,
   ).length;
   const resultCount = filteredAlumni.length;
 
@@ -148,7 +153,7 @@ const AlumniList = () => {
               {filteredAlumni.slice(0, 8).map((a, index) => (
                 <div
                   className="col-12 col-sm-6 col-md-6 col-lg-3 d-flex justify-content-center"
-                  key={index}
+                  key={a._id || a.id || index}
                 >
                   <div className="card alumni-card border-0 shadow-sm">
                     <div className="text-center pt-4">
@@ -164,7 +169,7 @@ const AlumniList = () => {
                     </div>
 
                     <div className="card-body text-center">
-                      <h6 className="fw-semibold mb-2">{a.name}</h6>
+                      <h6 className="fw-semibold mb-2">{a.name || "Unnamed Alumni"}</h6>
 
                       <span
                         className={`badge px-3 py-2 mb-3 ${
@@ -180,7 +185,7 @@ const AlumniList = () => {
 
                       <div className="text-start small mt-3">
                         <p>
-                          <strong>Email:</strong> {a.email}
+                          <strong>Email:</strong> {a.email || "N/A"}
                         </p>
                         <p>
                           <strong>Course:</strong>{" "}

--- a/frontend/src/components/Careers.jsx
+++ b/frontend/src/components/Careers.jsx
@@ -30,11 +30,16 @@ const Careers = () => {
     useEffect(() => {
         axios.get(`${baseUrl}/jobs`, { withCredentials: true })
             .then((res) => {
-                console.log(res.data);
-                setJobs(res.data);
+                const safeJobs = Array.isArray(res.data)
+                    ? res.data.filter((job) => job && typeof job === 'object')
+                    : [];
+                setJobs(safeJobs);
                 setLoading(false);
             })
-            .catch((err) => console.log(err));
+            .catch((err) => {
+                console.log(err);
+                setLoading(false);
+            });
     }, []);
 
     useEffect(() => {
@@ -47,11 +52,13 @@ const Careers = () => {
 
     useEffect(() => {
         // Filter the forum topics based on the search query
-        const filteredCareer = jobs.filter(career =>
-            career.job_title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            career.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            career.location.toLowerCase().includes(searchQuery.toLowerCase())
-        );
+        const query = searchQuery.toLowerCase();
+        const filteredCareer = jobs.filter((career) => {
+            const title = (career?.job_title || career?.title || '').toLowerCase();
+            const description = (career?.description || '').toLowerCase();
+            const location = (career?.location || '').toLowerCase();
+            return title.includes(query) || description.includes(query) || location.includes(query);
+        });
         setFilteredJob(filteredCareer);
     }, [searchQuery, jobs]);
 
@@ -108,22 +115,22 @@ const Careers = () => {
                         {filteredJob.length > 0 ? <>
                             {/* $event = $conn->query("SELECT c.*,u.name from careers c inner join users u on u.id = c.user_id order by id desc"); */}
                             {filteredJob.map((j, index) => (
-                                <div className="card job-list" key={index}>
+                                <div className="card job-list" key={j._id || j.id || index}>
                                     <div className="card-body">
                                         <div className="row  align-items-center justify-content-center text-center h-100">
                                             <div className="">
-                                                <h3><b className="filter-txt">{j.title}</b></h3>
+                                                <h3><b className="filter-txt">{j.job_title || j.title || 'Untitled Job'}</b></h3>
                                                 <div>
-                                                    <span className="filter-txt"><small><b><FaBuilding />{j.company}</b></small></span>{" "}
-                                                    <span className="filter-txt"><small><b><FaMapMarker />{j.location}</b></small></span>
+                                                    <span className="filter-txt"><small><b><FaBuilding />{j.company || 'Unknown Company'}</b></small></span>{" "}
+                                                    <span className="filter-txt"><small><b><FaMapMarker />{j.location || 'Location not specified'}</b></small></span>
                                                 </div>
                                                 <hr />
-                                                <p dangerouslySetInnerHTML={{ __html: j.description }} className="truncate filter-txt" ></p>
+                                                <p dangerouslySetInnerHTML={{ __html: j.description || '' }} className="truncate filter-txt" ></p>
                                                 <br />
                                                 <hr className="divider" style={{ maxWidth: "calc(80%)" }} />
                                                 <div className='jobbtn d-flex justify-content-between align-items-center '>
                                                     <span className="badge badge-info ">
-                                                        <b><i>Posted by: {j.user.name}</i></b>
+                                                        <b><i>Posted by: {j.user?.name || 'Unknown'}</i></b>
                                                     </span>
                                                     <button className="btn btn-sm  btn-primary " onClick={() => openModal(j)}>Read More</button>
                                                 </div>

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
closes #27 
This PR fixes frontend crashes on job-related pages caused by unsafe property access when API responses include null entries or missing nested objects (for example user: null).
The main issue was rendering code reading fields like [job.user.name](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/gitfo/.vscode/extensions/openai.chatgpt-0.4.74-win32-x64/webview/#) without guards, which caused Cannot read properties of null (reading 'name') and broke page rendering.

What was changed

Added response sanitization for jobs/applications/alumni/users lists (filter out invalid items).
Added null-safe fallbacks on job pages and admin job tables ([user?.name](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/gitfo/.vscode/extensions/openai.chatgpt-0.4.74-win32-x64/webview/#), fallback text for missing company/title/location).
Hardened filtering/search logic to handle missing strings safely.
Updated keys and display fallbacks to prevent unstable rendering.