### PR TITLE
fix: mentorship and news page links

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,9 @@ import Home from "./components/Home";
 import AlumniList from "./components/AlumniList";
 import Gallery from "./components/Gallery";
 import Careers from "./components/Careers";
+import Mentorship from "./components/Mentorship";
 import Forum from "./components/Forum";
+import News from "./components/News";
 import About from "./components/About";
 import Contact from "./components/Contact";
 import TermsOfService from "./components/TermsOfService";
@@ -86,7 +88,9 @@ function AppRouter() {
         <Route path="/alumni" element={<AlumniList />} />
         <Route path="/gallery" element={<Gallery />} />
         <Route path="/jobs" element={<Careers />} />
+        <Route path="/mentorship" element={<Mentorship />} />
         <Route path="/forums" element={<Forum />} />
+        <Route path="/news" element={<News />} />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/terms" element={<TermsOfService />} />


### PR DESCRIPTION
## Pull Request

### **Description:**
This PR resolves the broken links for the Mentorship and News pages. Previously, navigating to these pages resulted in a "That opportunity is no longer here" error because the frontend and backend were not properly connected. 

### **Changes:**
* Fixed the navigation links and routing for the Mentorship page.
* Fixed the navigation links and routing for the News page.
* Verified that both pages now load properly without errors.

### **Screenshots:**
<img width="1366" height="768" alt="Screenshot from 2026-02-19 17-55-13" src="https://github.com/user-attachments/assets/d158bacd-8029-402e-984a-95eca800d934" />
<img width="1366" height="768" alt="Screenshot from 2026-02-19 17-55-28" src="https://github.com/user-attachments/assets/24d51005-c7d6-4a79-9cfe-25b3aaf182fa" />


### **Related Issue:**
* Fixes #68
