### PR TITLE
fix: events detail page not visible

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import Login from "./components/Login";
 import Signup from "./components/Signup";
 import MyAccount from "./components/MyAccount";
 import NotFound from "./components/NotFound";
+import ViewEvent from "./components/view/View_Event";
 
 // Admin
 import Dashboard from "./admin/Dashboard";
@@ -98,6 +99,7 @@ function AppRouter() {
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/events/view" element={<ViewEvent />} />
 
         {/* Admin Dashboard */}
         <Route


### PR DESCRIPTION
## Pull Request

### Description
This PR fixes issue #73 where the Event Details page was not visible when a user clicked "Read More" from the Home page. The `/events/view` route was missing from the router configuration, causing the app to fall back to the NotFound component.

### Changes Made
- Imported the `View_Event` component into `frontend/src/App.jsx`.
- Added the `/events/view` path to the Public Routes configuration.

### Related Issue
Fixes #73

### Testing
- [x] Logged into the website.
- [x] Clicked "Read More" on an upcoming event on the Home page.
- [x] Verified the Event Details page is now fully visible.

### Screenshot:
<img width="1366" height="768" alt="Screenshot from 2026-02-20 17-56-35" src="https://github.com/user-attachments/assets/8db00c13-1339-4fff-82ae-65f91be859fb" />
