### PR TITLE
fix: redirect View Topic button to correct forum details page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Gallery from "./components/Gallery";
 import Careers from "./components/Careers";
 import Mentorship from "./components/Mentorship";
 import Forum from "./components/Forum";
+import ViewTopic from "./components/view/View_Forum";
 import News from "./components/News";
 import About from "./components/About";
 import Contact from "./components/Contact";
@@ -92,6 +93,7 @@ function AppRouter() {
         <Route path="/jobs" element={<Careers />} />
         <Route path="/mentorship" element={<Mentorship />} />
         <Route path="/forums" element={<Forum />} />
+        <Route path="/forum/view" element={<ViewTopic />} />
         <Route path="/news" element={<News />} />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />


### PR DESCRIPTION
## Description

This PR fixes the 404 error that occurred when users clicked the "View Topic" button in the Forum section.

## Problem

The "View Topic" button navigated to `/forum/view`, but this route was not properly configured in the router. As a result, the application fell back to the `NotFound` component and displayed a 404 page.

## Solution

- Added the missing `/forum/view` route in `App.js`
- Linked it to the existing `ViewTopic` component
- Ensured proper navigation using `navigate()` from the Forum page

## Result

Users can now successfully view forum topics without encountering a 404 error.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- Verified navigation from Forum page
- Confirmed that `/forum/view` loads the correct component
- Confirmed no regression in Admin or Student routes