### PR TITLE
fix: popup blocks fix

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 import { AuthProvider, useAuth } from "./AuthContext";
 import { ThemeProvider } from "./ThemeContext";
 import ScrollToTop from "./components/ScrollToTop";
@@ -85,6 +86,12 @@ function AppRouter() {
   return (
     <>
       {!hideLayout && <Header />}
+      <ToastContainer
+        position="top-center"
+        hideProgressBar
+        pauseOnHover={false}
+        pauseOnFocusLoss={false}
+      />
 
       <Routes>
         {/* Public Routes */}

--- a/frontend/src/admin/AdminAlumni.jsx
+++ b/frontend/src/admin/AdminAlumni.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { FaPlus } from "react-icons/fa";
 import axios from 'axios';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import defaultavatar from "../assets/uploads/defaultavatar.jpg"
 import { baseUrl, toPublicUrl } from '../utils/globalurl';
 
@@ -36,9 +36,7 @@ const AdminAlumni = () => {
 
   return (
     <>
-      <ToastContainer position="top-center" />
-
-      <div className="container-fluid">
+<div className="container-fluid">
 
         <div className="col-lg-12">
           <div className="row mb-4 mt-4">
@@ -130,3 +128,4 @@ const AdminAlumni = () => {
 }
 
 export default AdminAlumni
+

--- a/frontend/src/admin/AdminCourses.jsx
+++ b/frontend/src/admin/AdminCourses.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 
 const AdminCourses = () => {
@@ -87,8 +87,7 @@ const AdminCourses = () => {
 
   return (
     <div className="container-fluid">
-      <ToastContainer position="top-center" />
-      <div className="col-lg-12">
+<div className="col-lg-12">
         <div className="row">
           <div className="col-md-4">
             <form >
@@ -176,3 +175,4 @@ const AdminCourses = () => {
 }
 
 export default AdminCourses;
+

--- a/frontend/src/admin/AdminEvents.jsx
+++ b/frontend/src/admin/AdminEvents.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FaPlus } from 'react-icons/fa';
 import axios from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 
 const AdminEvents = () => {
@@ -46,8 +46,7 @@ const AdminEvents = () => {
 
   return (
     <div className="container-fluid">
-      <ToastContainer position="top-center" />
-      <div className="col-lg-12">
+<div className="col-lg-12">
         <div className="row mb-4 mt-4">
           <div className="col-md-12"></div>
         </div>
@@ -108,3 +107,4 @@ const AdminEvents = () => {
 };
 
 export default AdminEvents;
+

--- a/frontend/src/admin/AdminForum.jsx
+++ b/frontend/src/admin/AdminForum.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FaPlus } from "react-icons/fa";
 import axios from 'axios';
 import { Link, useNavigate } from 'react-router-dom'
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 
 
@@ -48,9 +48,7 @@ const AdminForum = () => {
 
   return (
     <>
-      <ToastContainer position="top-center" />
-
-      <div className="container-fluid">
+<div className="container-fluid">
         <div className="col-lg-12">
           <div className="row mb-4 mt-4">
             <div className="col-md-12">

--- a/frontend/src/admin/AdminGallery.jsx
+++ b/frontend/src/admin/AdminGallery.jsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl, toPublicUrl } from '../utils/globalurl';
 
 const AdminGallery = () => {
@@ -87,8 +87,7 @@ const AdminGallery = () => {
 
   return (
     <div className="container-fluid">
-      <ToastContainer position="top-center" />
-      <div className="row">
+<div className="row">
         <div className="col-lg-4 col-md-12">
           <form onSubmit={handleSubmit} id="manage-gallery">
             <div className="card">
@@ -164,3 +163,4 @@ const AdminGallery = () => {
 }
 
 export default AdminGallery;
+

--- a/frontend/src/admin/AdminJobApplications.jsx
+++ b/frontend/src/admin/AdminJobApplications.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import axios from 'axios';
 import { baseUrl } from '../utils/globalurl';
 import { FaBriefcase, FaUser, FaCheckCircle, FaTimesCircle, FaClock } from 'react-icons/fa';
@@ -79,9 +79,7 @@ const AdminJobApplications = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      <div className="row mb-4">
+<div className="row mb-4">
         <div className="col-lg-12">
           <h3 className="mb-4">
             <FaBriefcase className="me-2" />
@@ -219,3 +217,4 @@ const AdminJobApplications = () => {
 };
 
 export default AdminJobApplications;
+

--- a/frontend/src/admin/AdminJobs.jsx
+++ b/frontend/src/admin/AdminJobs.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { FaPlus } from "react-icons/fa";
 import { Link, useLocation } from "react-router-dom";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 // import 'react-toastify/dist/ReactToastify.css';
 import ViewJobs from './view/ViewJobs';
 import { baseUrl } from '../utils/globalurl';
@@ -52,9 +52,7 @@ const AdminJobs = () => {
     }
     return (
         <>
-            <ToastContainer position="top-center" />
-
-            <div className="container-fluid">
+<div className="container-fluid">
                 <div className="col-lg-12">
                     <div className="row mb-4 mt-4">
                         <div className="col-md-12"></div>
@@ -118,3 +116,4 @@ const AdminJobs = () => {
 }
 
 export default AdminJobs;
+

--- a/frontend/src/admin/AdminNews.jsx
+++ b/frontend/src/admin/AdminNews.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from "axios";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { FaPlus, FaEdit, FaTrash, FaNewspaper, FaEnvelope, FaUsers } from 'react-icons/fa';
 import { useTheme } from '../ThemeContext';
 import { baseUrl } from '../utils/globalurl';
@@ -146,9 +146,7 @@ const AdminNews = () => {
 
     return (
         <div className={`page-section bg-${theme}`}>
-            <ToastContainer hideProgressBar="true" position="top-center" pauseOnHover="false" pauseOnFocusLoss="false" />
-            
-            <div className="container-fluid">
+<div className="container-fluid">
                 <div className="d-flex justify-content-between align-items-center mb-4">
                     <h2 className="section-heading text-uppercase mb-0">
                         <FaNewspaper className="me-2" />
@@ -416,3 +414,4 @@ const AdminNews = () => {
 };
 
 export default AdminNews;
+

--- a/frontend/src/admin/AdminUsers.jsx
+++ b/frontend/src/admin/AdminUsers.jsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { FaPlus, FaEdit, FaTrash } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 
 const AdminUsers = () => {
@@ -30,9 +30,7 @@ const AdminUsers = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      {/* <div className="row">
+{/* <div className="row">
         <div className="col-lg-12">
           <button onClick={()=>navigate("/dashboard/users/manage")} className="btn btn-primary float-right btn-sm" id="new_user">
             <FaPlus /> New user
@@ -84,3 +82,4 @@ const AdminUsers = () => {
 };
 
 export default AdminUsers;
+

--- a/frontend/src/admin/save/ManageEvents.jsx
+++ b/frontend/src/admin/save/ManageEvents.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { FaTimes } from "react-icons/fa";
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import ReactQuill from 'react-quill';
 import { baseUrl } from '../../utils/globalurl';
 
@@ -73,8 +73,7 @@ const ManageEvents = () => {
     return (
         <>
             <div className="container-fluid">
-                <ToastContainer />
-                <div className="col-lg-12">
+<div className="col-lg-12">
                     <div className="card">
                         <div className="card-body">
                             <form action="" id="manage-event">

--- a/frontend/src/admin/save/ManageForum.jsx
+++ b/frontend/src/admin/save/ManageForum.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import axios from 'axios'
-import { ToastContainer, toast } from 'react-toastify'
+import { toast } from 'react-toastify'
 import ReactQuill from 'react-quill'
 import { baseUrl } from '../../utils/globalurl'
 
@@ -74,8 +74,7 @@ const ManageForum = ({ setHandleAdd }) => {
 
   return (
     <div className="container-fluid">
-      <ToastContainer position="top-center" />
-      <form onSubmit={handleSubmit}>
+<form onSubmit={handleSubmit}>
         <div className="form-group row">
           <label className="col-md-2 col-form-label">Title</label>
           <div className="col-md-8">
@@ -127,3 +126,4 @@ const ManageForum = ({ setHandleAdd }) => {
 }
 
 export default ManageForum
+

--- a/frontend/src/admin/save/ManageJobs.jsx
+++ b/frontend/src/admin/save/ManageJobs.jsx
@@ -2,8 +2,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Bounce, ToastContainer, toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import { Bounce, toast } from 'react-toastify';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
@@ -129,8 +128,7 @@ const ManageJobs = ({ setHandleAdd }) => {
 
   return (
     <>
-      <ToastContainer position="top-center" />
-      <div className="container-fluid">
+<div className="container-fluid">
         <form onSubmit={handleSubmit}>
           <div className="row form-group">
             <div className="col-md-8">
@@ -169,3 +167,4 @@ const ManageJobs = ({ setHandleAdd }) => {
 };
 
 export default ManageJobs;
+

--- a/frontend/src/admin/save/ManageUser.jsx
+++ b/frontend/src/admin/save/ManageUser.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../../utils/globalurl';
 
 
@@ -44,8 +44,7 @@ const ManageUser = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-            <div className="container-fluid">
+<div className="container-fluid">
                 <div id="msg"></div>
                 <form onSubmit={handleSubmit} id="manage-user">
                     <input type="hidden" name="id" value="id" />

--- a/frontend/src/admin/view/ViewAlumni.jsx
+++ b/frontend/src/admin/view/ViewAlumni.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import defaultavatar from "../../assets/uploads/defaultavatar.jpg";
 import { baseUrl, toPublicUrl } from '../../utils/globalurl';
 // import { baseUrl } from '../../utils/globalurl';
@@ -39,8 +39,7 @@ const ViewAlumni = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-            <div className="container-field">
+<div className="container-field">
                 <div className="col-lg-12">
                     <div>
                         <center>
@@ -85,3 +84,4 @@ const ViewAlumni = () => {
 }
 
 export default ViewAlumni
+

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import {
     FiArrowRight,
     FiBook,
@@ -193,9 +193,7 @@ const Home = () => {
 
     return (
         <div className={`home-page ${theme === 'dark' ? 'home-theme-dark' : 'home-theme-light'}`}>
-            <ToastContainer hideProgressBar position="top-center" pauseOnHover={false} pauseOnFocusLoss={false} />
-
-            <section className="home-hero">
+<section className="home-hero">
                 <img src={imgcs} alt="" className="home-hero-image" />
                 <div className="home-hero-mask" />
                 <motion.div
@@ -474,3 +472,4 @@ const Home = () => {
 };
 
 export default Home;
+

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import axios from "axios";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { useAuth } from '../AuthContext';
 import { authUrl } from '../utils/globalurl';
 
@@ -45,9 +45,7 @@ const Login = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-
-            <header className="masthead">
+<header className="masthead">
                 <div className="container-fluid h-100">
                     <div className="row h-100 align-items-center justify-content-center text-center">
                         <div className="col-lg-8 align-self-end mb-4 page-title">
@@ -116,3 +114,4 @@ const Login = () => {
 };
 
 export default Login;
+

--- a/frontend/src/components/MyAccount.jsx
+++ b/frontend/src/components/MyAccount.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { FaStar } from 'react-icons/fa';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 import { useAuth } from '../AuthContext';
 const MyAccount = () => {
@@ -88,8 +88,7 @@ const MyAccount = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-            <header className="masthead">
+<header className="masthead">
                 <div className="container-fluid h-100">
                     <div className="row h-100 align-items-center justify-content-center text-center">
                         <div className="col-lg-8 align-self-end mb-4 page-title">
@@ -237,3 +236,4 @@ const MyAccount = () => {
 }
 
 export default MyAccount;
+

--- a/frontend/src/components/News.jsx
+++ b/frontend/src/components/News.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from "axios";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { FaNewspaper, FaCalendar, FaUser, FaTag } from 'react-icons/fa';
 import { useTheme } from '../ThemeContext';
 import { baseUrl } from '../utils/globalurl';
@@ -71,8 +71,7 @@ const News = () => {
 
     return (
         <div className={`page-section bg-${theme}`} id="news">
-            <ToastContainer hideProgressBar="true" position="top-center" pauseOnHover="false" pauseOnFocusLoss="false" />
-            <div className="container">
+<div className="container">
                 <div className="text-center mb-5">
                     <h2 className="section-heading text-uppercase">News & Announcements</h2>
                     <h3 className="section-subheading text-muted">Stay updated with the latest from our alumni community</h3>
@@ -179,3 +178,4 @@ const News = () => {
 };
 
 export default News;
+

--- a/frontend/src/components/Newsletter.jsx
+++ b/frontend/src/components/Newsletter.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import axios from "axios";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { FaEnvelope, FaPaperPlane } from 'react-icons/fa';
 import { useTheme } from '../ThemeContext';
 import { baseUrl } from '../utils/globalurl';
@@ -33,8 +33,7 @@ const Newsletter = () => {
 
     return (
         <section className={`page-section newsletter-shell ${theme === 'light' ? 'newsletter-theme-light' : 'newsletter-theme-dark'}`} id="newsletter">
-            <ToastContainer hideProgressBar="true" position="top-center" pauseOnHover="false" pauseOnFocusLoss="false" />
-            <div className="container">
+<div className="container">
                 <div className="row justify-content-center">
                     <div className="col-lg-8 text-center">
                         <div className="newsletter-section newsletter-card p-4 rounded shadow-sm">
@@ -90,3 +89,4 @@ const Newsletter = () => {
 };
 
 export default Newsletter;
+

--- a/frontend/src/components/Signup.jsx
+++ b/frontend/src/components/Signup.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from "axios";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
 import { authUrl, baseUrl } from '../utils/globalurl';
 
@@ -53,8 +53,7 @@ const Signup = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" hideProgressBar />
-            <header className="masthead">
+<header className="masthead">
                 <div className="container-fluid h-100">
                     <div className="row h-100 align-items-center justify-content-center text-center">
                         <div className="col-lg-8 align-self-end mb-4 page-title">
@@ -175,3 +174,4 @@ const Signup = () => {
 }
 
 export default Signup
+

--- a/frontend/src/components/manage/Manage_Career.jsx
+++ b/frontend/src/components/manage/Manage_Career.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import React, { useState } from 'react'
 import ReactQuill from 'react-quill';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../../utils/globalurl';
 
 
@@ -42,8 +42,7 @@ const Manage_Career = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-            <div className="container-fluid">
+<div className="container-fluid">
                 <form onSubmit={handleSubmit}>
                     <input type="hidden" name="id" value={formData.id} className="form-control" />
                     <div className="row form-group">

--- a/frontend/src/components/view/View_Forum.jsx
+++ b/frontend/src/components/view/View_Forum.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FaComments } from "react-icons/fa";
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { useAuth } from '../../AuthContext';
 import { baseUrl } from '../../utils/globalurl';
 
@@ -103,8 +103,7 @@ const ViewTopic = () => {
 
     return (
         <>
-            <ToastContainer position="top-center" />
-            <header className="masthead">
+<header className="masthead">
                 <div className="container-fluid h-100">
                     <div className="row h-100 align-items-center justify-content-center text-center">
                         <div className="col-lg-8 align-self-end mb-4 page-title">
@@ -236,3 +235,4 @@ const ViewTopic = () => {
 };
 
 export default ViewTopic;
+

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import 'react-toastify/dist/ReactToastify.css'
 // import './index.css'; // Tailwind first
 // import 'bootstrap/dist/css/bootstrap.min.css'; // then Bootstrap
 // import 'bootstrap/dist/js/bootstrap.bundle.min.js';

--- a/frontend/src/students/StudentEvents.jsx
+++ b/frontend/src/students/StudentEvents.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { FaPlus } from 'react-icons/fa';
 import axios from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { baseUrl } from '../utils/globalurl';
 
 const StudentEvents = () => {
@@ -72,8 +72,7 @@ const StudentEvents = () => {
 
   return (
     <div className="container-fluid">
-      <ToastContainer position="top-center" />
-      <div className="col-lg-12">
+<div className="col-lg-12">
         <div className="row mb-4 mt-4">
           <div className="col-md-12"></div>
         </div>
@@ -139,3 +138,4 @@ const StudentEvents = () => {
 };
 
 export default StudentEvents;
+

--- a/frontend/src/students/StudentForum.jsx
+++ b/frontend/src/students/StudentForum.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import axios from 'axios';
 import { baseUrl } from '../utils/globalurl';
 import { FaComments, FaPlus, FaUser, FaClock } from 'react-icons/fa';
@@ -51,9 +51,7 @@ const StudentForum = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      <div className="row">
+<div className="row">
         <div className="col-lg-12">
           <div className="d-flex justify-content-between align-items-center mb-4">
             <h3>

--- a/frontend/src/students/StudentJobs.jsx
+++ b/frontend/src/students/StudentJobs.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import axios from 'axios';
 import { baseUrl } from '../utils/globalurl';
 import { FaBriefcase, FaMapMarkerAlt, FaUser } from 'react-icons/fa';
@@ -57,9 +57,7 @@ const StudentJobs = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      <div className="row">
+<div className="row">
         <div className="col-lg-12">
           <h3 className="mb-4">
             <FaBriefcase className="me-2" />

--- a/frontend/src/students/StudentProfile.jsx
+++ b/frontend/src/students/StudentProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import axios from 'axios';
 import {  studentUrl } from '../utils/globalurl';
 import { FaUser, FaEdit, FaSave, FaTimes } from 'react-icons/fa';
@@ -110,9 +110,7 @@ const StudentProfile = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      <div className="row">
+<div className="row">
         <div className="col-lg-12">
           <div className="d-flex justify-content-between align-items-center mb-4">
             <h3>

--- a/frontend/src/students/StudentsApplications.jsx
+++ b/frontend/src/students/StudentsApplications.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ToastContainer, toast } from 'react-toastify';
+import { toast } from 'react-toastify';
 import axios from 'axios';
 import { studentUrl } from '../utils/globalurl';
 import { FaBriefcase, FaBuilding, FaCheckCircle, FaClock, FaTimesCircle } from 'react-icons/fa';
@@ -47,9 +47,7 @@ const StudentsApplications = () => {
 
   return (
     <div className="container-fluid mt-4">
-      <ToastContainer position="top-center" />
-
-      <div className="row">
+<div className="row">
         <div className="col-lg-12">
           <h3 className="mb-4">
             <FaBriefcase className="me-2" />


### PR DESCRIPTION
This PR fixes the popup-related runtime crash:

Uncaught TypeError: Cannot set properties of undefined (setting 'toggle')

The issue was caused by multiple react-toastify containers being mounted/unmounted across pages and popup/modal flows.

Root Cause
react-toastify expects stable container registration.
With many page-level <ToastContainer /> instances, route/modal transitions could unmount containers while toast state updates were still being processed, causing setToggle to target an undefined entry.