### PR TITLE
fix: Badge/verification endpoints point to a non-existent backend path

### DIFF
--- a/frontend/src/utils/globalurl.js
+++ b/frontend/src/utils/globalurl.js
@@ -52,4 +52,4 @@ export const messagesUrl = `${apiUrl}/api/dm`;
 export const businessUrl = `${apiUrl}/api/business`;
 
 // Badges & Verification API endpoint
-export const badgeUrl = `${apiUrl}/api/admin/badges`;
+export const badgeUrl = `${apiUrl}/api`;


### PR DESCRIPTION
Fixed the endpoint mismatch by updating the shared frontend badge base URL.

Changed:
- globalurl.js
  - badgeUrl now points to ${apiUrl}/api instead of ${apiUrl}/api/admin/badges

Why this resolves the bug:
- Admin badges page builds URLs like badgeUrl + /badges, which now resolves to /api/badges.
- Admin verifications page builds URLs like badgeUrl + /verification/requests, which now resolves to /api/verification/requests.
- These match the backend mount and router paths in server.js and badge.routes.js.

I also verified there are no remaining frontend references to /api/admin/badges in src.

closes #150