### PR TITLE
bug:  Leaderboard uses an undefined variable for API base URL

### DIFF
--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { ToastContainer, toast } from 'react-toastify';
 import { FaTrophy, FaMedal, FaCrown, FaUsers } from 'react-icons/fa';
 import { useTheme } from '../ThemeContext';
-import { badgeUrl } from '../utils/globalurl';
+import { baseUrl } from '../utils/globalurl';
 
 const Leaderboard = () => {
     const { theme } = useTheme();


### PR DESCRIPTION
✅ Bug fixed! The issue was in the import statement on line 6 of Leaderboard.jsx. The component was importing `badgeUrl` but the code was using `baseUrl` in the API call. I've updated the import to use `baseUrl` from `../utils/globalurl`, which is now properly defined and available for the `fetchLeaderboard` function to use.

closes #151