### PR TITLE
fix:  Missing BlacklistedToken Import Causes Runtime Error on Logout

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -1,7 +1,7 @@
 const bycrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 
-const { User, Otp } = require('../models/Index');
+const { User, Otp, BlacklistedToken } = require('../models/Index');
 const sendEmail = require('../utils/mailer');
 
 const isProd = process.env.NODE_ENV === 'production';

--- a/backend/models/Index.js
+++ b/backend/models/Index.js
@@ -17,6 +17,7 @@ const MentorshipMessage = require('./MentorshipMessage.model');
 const JobReferral = require('./JobReferral.model');
 const JobSubscription = require('./JobSubscription.model');
 const Otp = require('./Otp.model');
+const BlacklistedToken = require('./BlacklistedToken.model');
 const Endorsement = require('./Endorsement.model');
 const DirectMessage = require('./DirectMessage.model');
 const Badge = require('./Badge.model');
@@ -44,6 +45,7 @@ module.exports = {
   JobReferral,
   JobSubscription,
   Otp,
+  BlacklistedToken,
   Endorsement,
   DirectMessage,
   Badge,


### PR DESCRIPTION
Fixed the logout crash by importing `BlacklistedToken` in auth.controller.js and exporting it from Index.js. That resolves the `ReferenceError` when `logout` calls `BlacklistedToken.updateOne(...)`.

Validation passed: the touched files have no static errors, and a Node load check confirmed `BlacklistedToken` resolves and the controller initializes successfully. The only output during the runtime check was unrelated Mongoose duplicate-index warnings already present in the app.

closes #177