### PR TITLE
fix: IDOR Vulnerability in Account Update Endpoint

### DIFF
--- a/backend/controllers/alumni.controller.js
+++ b/backend/controllers/alumni.controller.js
@@ -68,9 +68,10 @@ async function deleteAlumnus(req, res, next) {
 // update account with avatar upload
 async function updateAccount(req, res, next) {
     try {
-        const userId = req.body.user_id;
-        if (!userId) {
-            return res.status(400).json({ message: 'User id is required' });
+        const userId = req.user.id;
+
+        if (req.body.user_id && String(req.body.user_id) !== String(userId)) {
+            return res.status(403).json({ message: 'You can only update your own account' });
         }
 
         const currentUser = await User.findById(userId).select(

--- a/backend/test/alumni.updateAccount.test.js
+++ b/backend/test/alumni.updateAccount.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { User } = require('../models/Index');
+const { updateAccount } = require('../controllers/alumni.controller');
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+test('updateAccount rejects attempts to update a different user account', async () => {
+  const originalFindById = User.findById;
+  const originalFindByIdAndUpdate = User.findByIdAndUpdate;
+
+  let findByIdCalled = false;
+  User.findById = () => {
+    findByIdCalled = true;
+    throw new Error('findById should not be called for forbidden requests');
+  };
+  User.findByIdAndUpdate = () => {
+    throw new Error('findByIdAndUpdate should not be called for forbidden requests');
+  };
+
+  try {
+    const req = {
+      user: { id: 'user-1' },
+      body: { user_id: 'user-2' },
+    };
+    const res = createResponse();
+    let nextCalled = false;
+
+    await updateAccount(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.deepStrictEqual(res.payload, { message: 'You can only update your own account' });
+    assert.equal(findByIdCalled, false);
+    assert.equal(nextCalled, false);
+  } finally {
+    User.findById = originalFindById;
+    User.findByIdAndUpdate = originalFindByIdAndUpdate;
+  }
+});
+
+test('updateAccount uses the authenticated user id without requiring body user_id', async () => {
+  const originalFindById = User.findById;
+  const originalFindByIdAndUpdate = User.findByIdAndUpdate;
+
+  let lookedUpUserId = null;
+  let updatedUserId = null;
+  let updatePayload = null;
+
+  User.findById = (userId) => {
+    lookedUpUserId = userId;
+    return {
+      select: async () => ({
+        alumnus_bio: {
+          avatar: 'public/avatars/old.png',
+          avatar_public_id: 'old-avatar-id',
+        },
+      }),
+    };
+  };
+
+  User.findByIdAndUpdate = async (userId, payload) => {
+    updatedUserId = userId;
+    updatePayload = payload;
+  };
+
+  try {
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        gender: 'Female',
+        batch: '2024',
+        course_id: 'course-1',
+        connected_to: 'Mentors',
+        password: 'new-password',
+      },
+    };
+    const res = createResponse();
+
+    await updateAccount(req, res, () => {});
+
+    assert.equal(res.statusCode, 200);
+    assert.deepStrictEqual(res.payload, { message: 'Account updated successfully' });
+    assert.equal(lookedUpUserId, 'user-1');
+    assert.equal(updatedUserId, 'user-1');
+    assert.equal(updatePayload.name, 'Updated Name');
+    assert.equal(updatePayload.email, 'updated@example.com');
+    assert.equal(updatePayload['alumnus_bio.gender'], 'Female');
+    assert.equal(updatePayload['alumnus_bio.batch'], '2024');
+    assert.equal(updatePayload['alumnus_bio.course'], 'course-1');
+    assert.equal(updatePayload['alumnus_bio.connected_to'], 'Mentors');
+    assert.equal(updatePayload.password.startsWith('$2'), true);
+  } finally {
+    User.findById = originalFindById;
+    User.findByIdAndUpdate = originalFindByIdAndUpdate;
+  }
+});

--- a/frontend/src/components/MyAccount.jsx
+++ b/frontend/src/components/MyAccount.jsx
@@ -91,7 +91,6 @@ if (alumnusDetailsRes.data) {
     const handleSubmit = async (event) => {
         event.preventDefault();
         const alumnus_id = localStorage.getItem("alumnus_id");
-        const user_id = localStorage.getItem("user_id");
         const pswrd = document.getElementById("pswrd")?.value || "";
 
         try {
@@ -105,7 +104,6 @@ if (alumnusDetailsRes.data) {
             formData.append('password', pswrd);
             formData.append('batch', acc.batch);
             formData.append('alumnus_id', alumnus_id);
-            formData.append('user_id', user_id);
 
             const response = await axios.put(`${baseUrl}/alumni/account`, formData, { withCredentials: true });
             toast.success(response.data.message);


### PR DESCRIPTION
`updateAccount` now derives the target account from `req.user.id` and returns 403 when a legacy `user_id` in the body does not match the authenticated user. I also removed the `user_id` field from the account form submission so the frontend no longer relies on client-supplied ownership data. The change is in backend/controllers/alumni.controller.js, frontend/src/components/MyAccount.jsx, and the regression coverage is in backend/test/alumni.updateAccount.test.js.

I verified it with `node --test test/alumni.updateAccount.test.js`, and both the forbidden and allowed paths pass.

closes #179