### PR TITLE
180

### DIFF
--- a/backend/controllers/alumni.controller.js
+++ b/backend/controllers/alumni.controller.js
@@ -68,9 +68,10 @@ async function deleteAlumnus(req, res, next) {
 // update account with avatar upload
 async function updateAccount(req, res, next) {
     try {
-        const userId = req.body.user_id;
-        if (!userId) {
-            return res.status(400).json({ message: 'User id is required' });
+        const userId = req.user.id;
+
+        if (req.body.user_id && String(req.body.user_id) !== String(userId)) {
+            return res.status(403).json({ message: 'You can only update your own account' });
         }
 
         const currentUser = await User.findById(userId).select(

--- a/backend/controllers/business.controller.js
+++ b/backend/controllers/business.controller.js
@@ -394,13 +394,23 @@ async function getBusinessReviews(req, res, next) {
 async function markReviewHelpful(req, res, next) {
   try {
     const { reviewId } = req.params;
+    const userId = req.user.id;
 
     const review = await BusinessReview.findById(reviewId);
     if (!review) {
       return res.status(404).json({ error: 'Review not found' });
     }
 
+    const hasAlreadyVoted = (review.helpfulBy || []).some(
+      (voterId) => voterId.toString() === String(userId)
+    );
+
+    if (hasAlreadyVoted) {
+      return res.status(409).json({ error: 'You already marked this review as helpful' });
+    }
+
     review.isHelpful += 1;
+    review.helpfulBy = [...(review.helpfulBy || []), userId];
     await review.save();
 
     res.json({

--- a/backend/models/BusinessReview.model.js
+++ b/backend/models/BusinessReview.model.js
@@ -35,6 +35,10 @@ const businessReviewSchema = new mongoose.Schema({
     type: Number,
     default: 0
   },
+  helpfulBy: {
+    type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    default: []
+  },
   isReported: {
     type: Boolean,
     default: false

--- a/backend/models/Index.js
+++ b/backend/models/Index.js
@@ -25,6 +25,8 @@ const UserBadge = require('./UserBadge.model');
 const Achievement = require('./Achievement.model');
 const Donation = require('./Donation.model');
 const DonationCampaign = require('./DonationCampaign.model');
+const Business = require('./Business.model');
+const BusinessReview = require('./BusinessReview.model');
 
 module.exports = {
   User,
@@ -52,5 +54,7 @@ module.exports = {
   UserBadge,
   Achievement,
   Donation,
-  DonationCampaign
+  DonationCampaign,
+  Business,
+  BusinessReview
 };

--- a/backend/routes/business.routes.js
+++ b/backend/routes/business.routes.js
@@ -21,7 +21,7 @@ router.patch('/my-business/status', authenticate, businessController.toggleMyBus
 router.post('/:businessId/reviews', authenticate, businessController.addReview);
 router.put('/reviews/:reviewId', authenticate, businessController.updateMyReview);
 router.delete('/reviews/:reviewId', authenticate, businessController.deleteMyReview);
-router.patch('/reviews/:reviewId/helpful', businessController.markReviewHelpful);
+router.patch('/reviews/:reviewId/helpful', authenticate, businessController.markReviewHelpful);
 
 // Admin routes
 router.get('/admin/all', authenticate, businessController.getAllBusinessesAdmin);

--- a/backend/test/alumni.updateAccount.test.js
+++ b/backend/test/alumni.updateAccount.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { User } = require('../models/Index');
+const { updateAccount } = require('../controllers/alumni.controller');
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+test('updateAccount rejects attempts to update a different user account', async () => {
+  const originalFindById = User.findById;
+  const originalFindByIdAndUpdate = User.findByIdAndUpdate;
+
+  let findByIdCalled = false;
+  User.findById = () => {
+    findByIdCalled = true;
+    throw new Error('findById should not be called for forbidden requests');
+  };
+  User.findByIdAndUpdate = () => {
+    throw new Error('findByIdAndUpdate should not be called for forbidden requests');
+  };
+
+  try {
+    const req = {
+      user: { id: 'user-1' },
+      body: { user_id: 'user-2' },
+    };
+    const res = createResponse();
+    let nextCalled = false;
+
+    await updateAccount(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.deepStrictEqual(res.payload, { message: 'You can only update your own account' });
+    assert.equal(findByIdCalled, false);
+    assert.equal(nextCalled, false);
+  } finally {
+    User.findById = originalFindById;
+    User.findByIdAndUpdate = originalFindByIdAndUpdate;
+  }
+});
+
+test('updateAccount uses the authenticated user id without requiring body user_id', async () => {
+  const originalFindById = User.findById;
+  const originalFindByIdAndUpdate = User.findByIdAndUpdate;
+
+  let lookedUpUserId = null;
+  let updatedUserId = null;
+  let updatePayload = null;
+
+  User.findById = (userId) => {
+    lookedUpUserId = userId;
+    return {
+      select: async () => ({
+        alumnus_bio: {
+          avatar: 'public/avatars/old.png',
+          avatar_public_id: 'old-avatar-id',
+        },
+      }),
+    };
+  };
+
+  User.findByIdAndUpdate = async (userId, payload) => {
+    updatedUserId = userId;
+    updatePayload = payload;
+  };
+
+  try {
+    const req = {
+      user: { id: 'user-1' },
+      body: {
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        gender: 'Female',
+        batch: '2024',
+        course_id: 'course-1',
+        connected_to: 'Mentors',
+        password: 'new-password',
+      },
+    };
+    const res = createResponse();
+
+    await updateAccount(req, res, () => {});
+
+    assert.equal(res.statusCode, 200);
+    assert.deepStrictEqual(res.payload, { message: 'Account updated successfully' });
+    assert.equal(lookedUpUserId, 'user-1');
+    assert.equal(updatedUserId, 'user-1');
+    assert.equal(updatePayload.name, 'Updated Name');
+    assert.equal(updatePayload.email, 'updated@example.com');
+    assert.equal(updatePayload['alumnus_bio.gender'], 'Female');
+    assert.equal(updatePayload['alumnus_bio.batch'], '2024');
+    assert.equal(updatePayload['alumnus_bio.course'], 'course-1');
+    assert.equal(updatePayload['alumnus_bio.connected_to'], 'Mentors');
+    assert.equal(updatePayload.password.startsWith('$2'), true);
+  } finally {
+    User.findById = originalFindById;
+    User.findByIdAndUpdate = originalFindByIdAndUpdate;
+  }
+});

--- a/backend/test/business.reviewHelpful.test.js
+++ b/backend/test/business.reviewHelpful.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+
+const businessRoutes = require('../routes/business.routes');
+const BusinessReview = require('../models/BusinessReview.model');
+const { markReviewHelpful } = require('../controllers/business.controller');
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+test('PATCH /reviews/:reviewId/helpful rejects unauthenticated requests with 401', async (t) => {
+  const app = express();
+  app.use(cookieParser());
+  app.use('/api/business', businessRoutes);
+
+  const server = app.listen(0);
+  t.after(() => server.close());
+
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/business/reviews/507f1f77bcf86cd799439011/helpful`, {
+    method: 'PATCH',
+  });
+
+  assert.equal(response.status, 401);
+  assert.deepStrictEqual(await response.json(), { error: 'Unauthorized' });
+});
+
+test('markReviewHelpful blocks duplicate votes from the same user', async () => {
+  const originalFindById = BusinessReview.findById;
+
+  const savedReview = {
+    isHelpful: 3,
+    helpfulBy: ['user-1'],
+    save: async () => {},
+  };
+
+  BusinessReview.findById = async () => savedReview;
+
+  try {
+    const req = {
+      params: { reviewId: 'review-1' },
+      user: { id: 'user-1' },
+    };
+    const res = createResponse();
+
+    await markReviewHelpful(req, res, () => {});
+
+    assert.equal(res.statusCode, 409);
+    assert.deepStrictEqual(res.payload, { error: 'You already marked this review as helpful' });
+    assert.equal(savedReview.isHelpful, 3);
+    assert.deepStrictEqual(savedReview.helpfulBy, ['user-1']);
+  } finally {
+    BusinessReview.findById = originalFindById;
+  }
+});
+
+test('markReviewHelpful counts a unique helpful vote once', async () => {
+  const originalFindById = BusinessReview.findById;
+
+  const savedReview = {
+    isHelpful: 3,
+    helpfulBy: ['user-1'],
+    save: async () => {},
+  };
+
+  BusinessReview.findById = async () => savedReview;
+
+  try {
+    const req = {
+      params: { reviewId: 'review-1' },
+      user: { id: 'user-2' },
+    };
+    const res = createResponse();
+
+    await markReviewHelpful(req, res, () => {});
+
+    assert.equal(res.statusCode, 200);
+    assert.deepStrictEqual(res.payload, {
+      message: 'Review marked as helpful',
+      isHelpful: 4,
+    });
+    assert.equal(savedReview.isHelpful, 4);
+    assert.deepStrictEqual(savedReview.helpfulBy, ['user-1', 'user-2']);
+  } finally {
+    BusinessReview.findById = originalFindById;
+  }
+});

--- a/frontend/src/components/MyAccount.jsx
+++ b/frontend/src/components/MyAccount.jsx
@@ -91,7 +91,6 @@ if (alumnusDetailsRes.data) {
     const handleSubmit = async (event) => {
         event.preventDefault();
         const alumnus_id = localStorage.getItem("alumnus_id");
-        const user_id = localStorage.getItem("user_id");
         const pswrd = document.getElementById("pswrd")?.value || "";
 
         try {
@@ -105,7 +104,6 @@ if (alumnusDetailsRes.data) {
             formData.append('password', pswrd);
             formData.append('batch', acc.batch);
             formData.append('alumnus_id', alumnus_id);
-            formData.append('user_id', user_id);
 
             const response = await axios.put(`${baseUrl}/alumni/account`, formData, { withCredentials: true });
             toast.success(response.data.message);


### PR DESCRIPTION
The review-helpful endpoint is now protected and vote-limited. I added `authenticate` to backend/routes/business.routes.js, updated backend/controllers/business.controller.js to record `helpfulBy` user IDs and reject repeat votes with 409, and added the `helpfulBy` array to backend/models/BusinessReview.model.js. I also exported `BusinessReview` from backend/models/Index.js so the controller can use it.

Validation passed with `node --test test/business.reviewHelpful.test.js`, including a 401 check for unauthenticated requests and duplicate-vote coverage.

closes #180