### PR TITLE
fix: MongoDB Text Search Used Without Text Indexes

### DIFF
--- a/backend/migrate-text-indexes.js
+++ b/backend/migrate-text-indexes.js
@@ -1,0 +1,87 @@
+/**
+ * Migration Script: Ensure MongoDB text indexes for search endpoints
+ *
+ * Purpose:
+ * - Ensure User and Business search indexes exist in deployed environments
+ * - Print final index lists for quick verification
+ *
+ * Usage:
+ * - npm run migrate:text-indexes
+ */
+
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const { User, Business } = require('./models/Index');
+
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/alumni_db';
+
+async function connectDB() {
+  await mongoose.connect(MONGODB_URI);
+  console.log('✅ Connected to MongoDB');
+}
+
+function findTextIndex(indexes) {
+  return indexes.find((idx) => Object.values(idx.key || {}).includes('text'));
+}
+
+async function ensureTextIndex(model, label, key, name) {
+  const indexes = await model.collection.indexes();
+  const existingText = findTextIndex(indexes);
+
+  if (existingText) {
+    console.log(`ℹ️  ${label}: existing text index found (${existingText.name})`);
+    return;
+  }
+
+  await model.collection.createIndex(key, { name });
+  console.log(`✅ ${label}: created text index (${name})`);
+}
+
+async function ensureSearchIndexes() {
+  console.log('\n🔧 Ensuring required text indexes for search endpoints...');
+
+  await ensureTextIndex(
+    User,
+    'users',
+    { name: 'text', email: 'text', 'alumnus_bio.bio': 'text' },
+    'users_search_text_idx'
+  );
+
+  await ensureTextIndex(
+    Business,
+    'businesses',
+    { businessName: 'text', description: 'text' },
+    'businesses_search_text_idx'
+  );
+
+  const userIndexes = await User.collection.indexes();
+  const businessIndexes = await Business.collection.indexes();
+
+  console.log('\n📌 User indexes:');
+  userIndexes.forEach((idx) => {
+    console.log(`- ${idx.name}: ${JSON.stringify(idx.key)}`);
+  });
+
+  console.log('\n📌 Business indexes:');
+  businessIndexes.forEach((idx) => {
+    console.log(`- ${idx.name}: ${JSON.stringify(idx.key)}`);
+  });
+}
+
+async function run() {
+  try {
+    await connectDB();
+    await ensureSearchIndexes();
+    console.log('\n✨ Text index migration completed');
+  } catch (error) {
+    console.error('❌ Text index migration failed:', error.message);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+    console.log('🔌 Database connection closed');
+  }
+}
+
+run();

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "migrate": "node migrate-to-mongodb.js",
+    "migrate:text-indexes": "node migrate-text-indexes.js",
     "test": "node --test"
   },
   "keywords": [],


### PR DESCRIPTION
Implemented and verified. The core finding is that both schema text indexes were already present, and I added a safe migration path to enforce/verify them in deployed environments.

Changes made:
1. Added a new migration script: migrate-text-indexes.js
2. Added an npm script entry: package.json

What I verified:
1. User text index already exists in User.model.js
2. Business text index already exists in Business.model.js
3. Controllers use text search in:
- alumni.controller.js
- business.controller.js
4. Ran the migration locally with npm run migrate:text-indexes and confirmed:
- users has an existing text index
- businesses has an existing text index
- index lists printed successfully for both collections

Important command result summary:
1. Existing user text index found: name/email/alumnus_bio.bio plus additional indexed text fields.
2. Existing business text index found: businessName/description/tagline.
3. Migration completed successfully and closed DB connection.

Notes on your requested fix:
1. The specific fields you listed are already covered by current schema indexes.
2. The migration script now handles deployed environments by creating missing text indexes only when absent, and by printing final index state for verification.

How to run in any environment:
1. From backend folder: npm run migrate:text-indexes
2. Review printed User and Business index lists in terminal output.

closes #181