### PR TITLE
Referral Status Timeline

### DIFF
--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -1,17 +1,52 @@
 const { JobReferral, User, Badge, UserBadge } = require('../models/Index');
 const logger = require('../utils/logger');
 
+async function getCurrentUserSummary(userId) {
+  return User.findById(userId).select('_id name type');
+}
+
+function appendTimelineEvent(referral, event) {
+  if (!referral.timeline) {
+    referral.timeline = [];
+  }
+
+  referral.timeline.push({
+    action: event.action,
+    status: event.status,
+    scope: event.scope || 'referral',
+    timestamp: event.timestamp || new Date(),
+    actor: event.actor?._id || event.actor,
+    actorName: event.actorName,
+    actorType: event.actorType,
+    applicant: event.applicant?._id || event.applicant,
+    applicantName: event.applicantName,
+    details: event.details
+  });
+}
+
 // Create a new job referral opportunity
 async function createReferral(req, res, next) {
   try {
+    const currentUser = await getCurrentUserSummary(req.user.id);
     const referralData = {
       jobTitle: req.body.jobTitle,
       company: req.body.company,
       description: req.body.description,
       referralBonus: req.body.referralBonus || 0,
       deadline: req.body.deadline ? new Date(req.body.deadline) : null,
-      postedBy: req.user.id
+      postedBy: req.user.id,
+      timeline: []
     };
+
+    appendTimelineEvent(referralData, {
+      action: 'posted',
+      status: 'open',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      details: 'Referral posted'
+    });
 
     const referral = await JobReferral.create(referralData);
 
@@ -99,6 +134,11 @@ async function getReferrals(req, res, next) {
 async function applyForReferral(req, res, next) {
   try {
     const { id } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
+
+    if (!currentUser || currentUser.type !== 'student') {
+      return res.status(403).json({ message: 'Only students can apply for referrals' });
+    }
 
     const referral = await JobReferral.findById(id);
     if (!referral) {
@@ -125,6 +165,18 @@ async function applyForReferral(req, res, next) {
       user: req.user.id
     });
 
+    appendTimelineEvent(referral, {
+      action: 'applied',
+      status: 'pending',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser.name,
+      actorType: currentUser.type,
+      applicant: currentUser,
+      applicantName: currentUser.name,
+      details: `${currentUser.name} applied for this referral`
+    });
+
     await referral.save();
 
     await referral.populate('applicants.user', 'name email alumnus_bio');
@@ -142,9 +194,16 @@ async function applyForReferral(req, res, next) {
 async function acceptReferral(req, res, next) {
   try {
     const { id, applicantId } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
 
-    const referral = await JobReferral.findOne({ _id: id, postedBy: req.user.id });
+    const referral = await JobReferral.findById(id);
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ message: 'Access denied' });
     }
 
@@ -155,8 +214,34 @@ async function acceptReferral(req, res, next) {
       return res.status(404).json({ message: 'Applicant not found' });
     }
 
+    const applicantUser = await User.findById(applicantId).select('_id name');
+
     referral.applicants[applicantIndex].status = 'accepted';
     referral.status = 'filled'; // Close after accept
+
+    appendTimelineEvent(referral, {
+      action: 'accepted',
+      status: 'accepted',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: `${applicantUser?.name || 'Applicant'} was accepted`
+    });
+
+    appendTimelineEvent(referral, {
+      action: 'filled',
+      status: 'filled',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: 'Referral marked as filled'
+    });
 
     await referral.save();
 
@@ -175,9 +260,16 @@ async function acceptReferral(req, res, next) {
 async function rejectReferral(req, res, next) {
   try {
     const { id, applicantId } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
 
-    const referral = await JobReferral.findOne({ _id: id, postedBy: req.user.id });
+    const referral = await JobReferral.findById(id);
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ message: 'Access denied' });
     }
 
@@ -188,7 +280,21 @@ async function rejectReferral(req, res, next) {
       return res.status(404).json({ message: 'Applicant not found' });
     }
 
+    const applicantUser = await User.findById(applicantId).select('_id name');
+
     referral.applicants[applicantIndex].status = 'rejected';
+
+    appendTimelineEvent(referral, {
+      action: 'rejected',
+      status: 'rejected',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: `${applicantUser?.name || 'Applicant'} was rejected`
+    });
 
     await referral.save();
 
@@ -220,6 +326,66 @@ async function getReferralById(req, res, next) {
   }
 }
 
+async function getReferralTimeline(req, res, next) {
+  try {
+    const referral = await JobReferral.findById(req.params.id).select('timeline');
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const timeline = [...(referral.timeline || [])].sort(
+      (left, right) => new Date(left.timestamp) - new Date(right.timestamp)
+    );
+
+    res.json({ timeline });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function closeReferral(req, res, next) {
+  try {
+    const { id } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
+
+    const referral = await JobReferral.findById(id);
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+
+    if (referral.status === 'closed' || referral.status === 'filled') {
+      return res.status(400).json({ message: 'Referral is already closed' });
+    }
+
+    referral.status = 'closed';
+
+    appendTimelineEvent(referral, {
+      action: 'closed',
+      status: 'closed',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      details: 'Referral closed'
+    });
+
+    await referral.save();
+
+    res.json({
+      message: 'Referral closed successfully',
+      referral
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 // Get my referrals (posted by me)
 async function getMyReferrals(req, res, next) {
   try {
@@ -239,7 +405,9 @@ module.exports = {
   applyForReferral,
   acceptReferral,
   rejectReferral,
+  closeReferral,
   getMyReferrals,
-  getReferralById
+  getReferralById,
+  getReferralTimeline
 };
 

--- a/backend/models/JobReferral.model.js
+++ b/backend/models/JobReferral.model.js
@@ -1,5 +1,51 @@
 const mongoose = require('mongoose');
 
+const referralTimelineSchema = new mongoose.Schema({
+  action: {
+    type: String,
+    enum: ['posted', 'applied', 'accepted', 'rejected', 'filled', 'closed'],
+    required: true
+  },
+  status: {
+    type: String,
+    enum: ['open', 'pending', 'accepted', 'rejected', 'filled', 'closed'],
+    required: true
+  },
+  scope: {
+    type: String,
+    enum: ['referral', 'applicant'],
+    default: 'referral'
+  },
+  timestamp: {
+    type: Date,
+    default: Date.now
+  },
+  actor: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  actorName: {
+    type: String,
+    trim: true
+  },
+  actorType: {
+    type: String,
+    trim: true
+  },
+  applicant: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  applicantName: {
+    type: String,
+    trim: true
+  },
+  details: {
+    type: String,
+    trim: true
+  }
+}, { _id: false });
+
 // JobReferral Schema for standalone referral opportunities
 const jobReferralSchema = new mongoose.Schema({
   jobTitle: {
@@ -40,6 +86,7 @@ const jobReferralSchema = new mongoose.Schema({
       default: 'pending'
     }
   }],
+  timeline: [referralTimelineSchema],
   status: {
     type: String,
     enum: ['open', 'closed', 'filled'],

--- a/backend/routes/referral.routes.js
+++ b/backend/routes/referral.routes.js
@@ -5,9 +5,12 @@ const {
   applyForReferral,
   acceptReferral,
   rejectReferral,
-  getMyReferrals
+  closeReferral,
+  getMyReferrals,
+  getReferralById,
+  getReferralTimeline
 } = require('../controllers/referral.controller');
-const { authenticate } = require('../middlewares/auth.middleware');
+const { authenticate, isStudent } = require('../middlewares/auth.middleware');
 
 const router = express.Router();
 
@@ -18,17 +21,23 @@ router.post('/', authenticate, createReferral);
 router.get('/', authenticate, getReferrals);
 
 // Apply for referral
-router.post('/:id/apply', authenticate, applyForReferral);
+router.post('/:id/apply', authenticate, isStudent, applyForReferral);
 
 // Manage applicants (only poster)
 router.put('/:id/applicants/:applicantId/accept', authenticate, acceptReferral);
 router.put('/:id/applicants/:applicantId/reject', authenticate, rejectReferral);
 
-// Get single referral
-router.get('/:id', authenticate, getReferralById);
+// Close referral (poster/admin)
+router.patch('/:id/close', authenticate, closeReferral);
+
+// Get referral timeline
+router.get('/:id/timeline', authenticate, getReferralTimeline);
 
 // Get my referrals
 router.get('/my-referrals', authenticate, getMyReferrals);
+
+// Get single referral
+router.get('/:id', authenticate, getReferralById);
 
 module.exports = router;
 

--- a/frontend/src/components/ReferralDetail.jsx
+++ b/frontend/src/components/ReferralDetail.jsx
@@ -6,13 +6,16 @@ import { toast } from 'react-toastify';
 
 const ReferralDetail = () => {
   const { id } = useParams();
-  const { user } = useAuth();
   const navigate = useNavigate();
+  const { isAuthReady } = useAuth();
   const [referral, setReferral] = useState(null);
+  const [timeline, setTimeline] = useState([]);
   const [loading, setLoading] = useState(true);
   const [applying, setApplying] = useState(false);
-  const [isOwner, setIsOwner] = useState(false);
   const [applicants, setApplicants] = useState([]);
+
+  const currentUserId = localStorage.getItem('user_id');
+  const currentUserType = (localStorage.getItem('user_type') || '').toLowerCase();
 
   useEffect(() => {
     fetchReferral();
@@ -21,20 +24,25 @@ const ReferralDetail = () => {
   const fetchReferral = async () => {
     try {
       setLoading(true);
-      const response = await apiClient.get(`/api/referrals/${id}?populate=true`);
-      const data = response.data;
+      const [referralResponse, timelineResponse] = await Promise.all([
+        apiClient.get(`/api/referrals/${id}`),
+        apiClient.get(`/api/referrals/${id}/timeline`)
+      ]);
+
+      const data = referralResponse.data;
       setReferral(data);
       setApplicants(data.applicants || []);
-      setIsOwner(user && data.postedBy?._id === user.id);
+      setTimeline(timelineResponse.data?.timeline || []);
     } catch (err) {
       toast.error('Failed to load referral details');
+      setTimeline([]);
     } finally {
       setLoading(false);
     }
   };
 
   const handleApply = async () => {
-    if (!user) {
+    if (!currentUserId) {
       toast.error('Please login to apply');
       return;
     }
@@ -95,9 +103,34 @@ const ReferralDetail = () => {
   }
 
   const canApply = referral.status === 'open' && 
-    !referral.applicants?.some(app => app.user._id === user?.id) &&
-    user && 
-    !isOwner;
+    !referral.applicants?.some(app => (app.user?._id || app.user?.id || app.user) === currentUserId) &&
+    currentUserId && 
+    currentUserType === 'student' &&
+    (referral.postedBy?._id || referral.postedBy?.id || referral.postedBy) !== currentUserId;
+
+  const isOwner = Boolean(
+    currentUserId && (referral.postedBy?._id || referral.postedBy?.id || referral.postedBy) === currentUserId
+  );
+
+  const describeTimelineEvent = (event) => {
+    const actionMap = {
+      posted: 'Referral posted',
+      applied: 'Application submitted',
+      accepted: 'Applicant accepted',
+      rejected: 'Applicant rejected',
+      filled: 'Referral filled',
+      closed: 'Referral closed'
+    };
+
+    return actionMap[event.action] || event.action;
+  };
+
+  const timelineTone = (event) => {
+    if (event.status === 'accepted' || event.status === 'filled') return 'from-green-500 to-emerald-600';
+    if (event.status === 'rejected' || event.status === 'closed') return 'from-red-500 to-rose-600';
+    if (event.status === 'pending') return 'from-yellow-500 to-amber-500';
+    return 'from-blue-500 to-cyan-500';
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">
@@ -152,6 +185,54 @@ const ReferralDetail = () => {
               </div>
             </div>
 
+            {/* Timeline */}
+            <div className="bg-white rounded-2xl shadow-lg p-8 mb-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-900">Status Timeline</h2>
+                <span className="text-sm text-gray-500">Chronological activity feed</span>
+              </div>
+              {timeline.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-gray-200 p-6 text-gray-500">
+                  No timeline events yet.
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {timeline.map((event, index) => (
+                    <div key={`${event.timestamp}-${index}`} className="flex gap-4">
+                      <div className={`mt-1 h-3 w-3 rounded-full bg-gradient-to-r ${timelineTone(event)} shadow-sm`} />
+                      <div className="flex-1 pb-4 border-b border-gray-100 last:border-b-0">
+                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-gray-900">{describeTimelineEvent(event)}</p>
+                            <p className="text-sm text-gray-600">
+                              {event.actorName ? `by ${event.actorName}` : 'System'}
+                              {event.applicantName ? ` for ${event.applicantName}` : ''}
+                            </p>
+                          </div>
+                          <div className="text-sm text-gray-500">
+                            {event.timestamp ? new Date(event.timestamp).toLocaleString() : ''}
+                          </div>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-700">
+                            {String(event.status || '').toUpperCase()}
+                          </span>
+                          {event.scope && (
+                            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-blue-50 text-blue-700">
+                              {event.scope}
+                            </span>
+                          )}
+                        </div>
+                        {event.details && (
+                          <p className="mt-3 text-sm text-gray-600">{event.details}</p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
             {/* Apply Section */}
             {canApply && (
               <div className="bg-gradient-to-r from-green-500 to-emerald-600 rounded-2xl p-8 shadow-2xl mb-8">
@@ -174,7 +255,7 @@ const ReferralDetail = () => {
               </div>
             )}
 
-            {!user && (
+            {!currentUserId && (
               <div className="bg-yellow-50 border border-yellow-200 rounded-2xl p-8 mb-8">
                 <h3 className="text-xl font-bold text-yellow-900 mb-4">Login to Apply</h3>
                 <p className="text-yellow-800 mb-6">Sign in to your account to apply for this referral opportunity and track your applications.</p>


### PR DESCRIPTION
Implemented the referral status timeline end to end. The backend now stores an append-only timeline on each referral document, appends events when a referral is posted, applied to, accepted, rejected, or closed, and exposes `GET /api/referrals/:id/timeline` plus a poster/admin close action. The role checks are now enforced in the actual flow: students can apply, and only the poster or an admin can accept/reject/close. See JobReferral.model.js, referral.controller.js, and referral.routes.js.

On the UI side, ReferralDetail.jsx now fetches the timeline endpoint and renders a chronological activity feed with timestamps, status labels, and optional actor/applicant names. I also fixed the detail page to use the session ID stored in localStorage instead of a missing `user` object from auth context, so ownership and apply gating work with the existing auth setup. The edited files passed `get_errors`, and a direct Node module-load sanity check succeeded.

closes #201