### PR TITLE
Messaging inside Referral

### DIFF
--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -1,17 +1,52 @@
 const { JobReferral, User, Badge, UserBadge } = require('../models/Index');
 const logger = require('../utils/logger');
 
+async function getCurrentUserSummary(userId) {
+  return User.findById(userId).select('_id name type');
+}
+
+function appendTimelineEvent(referral, event) {
+  if (!referral.timeline) {
+    referral.timeline = [];
+  }
+
+  referral.timeline.push({
+    action: event.action,
+    status: event.status,
+    scope: event.scope || 'referral',
+    timestamp: event.timestamp || new Date(),
+    actor: event.actor?._id || event.actor,
+    actorName: event.actorName,
+    actorType: event.actorType,
+    applicant: event.applicant?._id || event.applicant,
+    applicantName: event.applicantName,
+    details: event.details
+  });
+}
+
 // Create a new job referral opportunity
 async function createReferral(req, res, next) {
   try {
+    const currentUser = await getCurrentUserSummary(req.user.id);
     const referralData = {
       jobTitle: req.body.jobTitle,
       company: req.body.company,
       description: req.body.description,
       referralBonus: req.body.referralBonus || 0,
       deadline: req.body.deadline ? new Date(req.body.deadline) : null,
-      postedBy: req.user.id
+      postedBy: req.user.id,
+      timeline: []
     };
+
+    appendTimelineEvent(referralData, {
+      action: 'posted',
+      status: 'open',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      details: 'Referral posted'
+    });
 
     const referral = await JobReferral.create(referralData);
 
@@ -99,6 +134,11 @@ async function getReferrals(req, res, next) {
 async function applyForReferral(req, res, next) {
   try {
     const { id } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
+
+    if (!currentUser || currentUser.type !== 'student') {
+      return res.status(403).json({ message: 'Only students can apply for referrals' });
+    }
 
     const referral = await JobReferral.findById(id);
     if (!referral) {
@@ -125,6 +165,18 @@ async function applyForReferral(req, res, next) {
       user: req.user.id
     });
 
+    appendTimelineEvent(referral, {
+      action: 'applied',
+      status: 'pending',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser.name,
+      actorType: currentUser.type,
+      applicant: currentUser,
+      applicantName: currentUser.name,
+      details: `${currentUser.name} applied for this referral`
+    });
+
     await referral.save();
 
     await referral.populate('applicants.user', 'name email alumnus_bio');
@@ -142,9 +194,16 @@ async function applyForReferral(req, res, next) {
 async function acceptReferral(req, res, next) {
   try {
     const { id, applicantId } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
 
-    const referral = await JobReferral.findOne({ _id: id, postedBy: req.user.id });
+    const referral = await JobReferral.findById(id);
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ message: 'Access denied' });
     }
 
@@ -155,8 +214,34 @@ async function acceptReferral(req, res, next) {
       return res.status(404).json({ message: 'Applicant not found' });
     }
 
+    const applicantUser = await User.findById(applicantId).select('_id name');
+
     referral.applicants[applicantIndex].status = 'accepted';
     referral.status = 'filled'; // Close after accept
+
+    appendTimelineEvent(referral, {
+      action: 'accepted',
+      status: 'accepted',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: `${applicantUser?.name || 'Applicant'} was accepted`
+    });
+
+    appendTimelineEvent(referral, {
+      action: 'filled',
+      status: 'filled',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: 'Referral marked as filled'
+    });
 
     await referral.save();
 
@@ -175,9 +260,16 @@ async function acceptReferral(req, res, next) {
 async function rejectReferral(req, res, next) {
   try {
     const { id, applicantId } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
 
-    const referral = await JobReferral.findOne({ _id: id, postedBy: req.user.id });
+    const referral = await JobReferral.findById(id);
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ message: 'Access denied' });
     }
 
@@ -188,7 +280,21 @@ async function rejectReferral(req, res, next) {
       return res.status(404).json({ message: 'Applicant not found' });
     }
 
+    const applicantUser = await User.findById(applicantId).select('_id name');
+
     referral.applicants[applicantIndex].status = 'rejected';
+
+    appendTimelineEvent(referral, {
+      action: 'rejected',
+      status: 'rejected',
+      scope: 'applicant',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      applicant: applicantUser?._id || applicantId,
+      applicantName: applicantUser?.name,
+      details: `${applicantUser?.name || 'Applicant'} was rejected`
+    });
 
     await referral.save();
 
@@ -220,6 +326,66 @@ async function getReferralById(req, res, next) {
   }
 }
 
+async function getReferralTimeline(req, res, next) {
+  try {
+    const referral = await JobReferral.findById(req.params.id).select('timeline');
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const timeline = [...(referral.timeline || [])].sort(
+      (left, right) => new Date(left.timestamp) - new Date(right.timestamp)
+    );
+
+    res.json({ timeline });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function closeReferral(req, res, next) {
+  try {
+    const { id } = req.params;
+    const currentUser = await getCurrentUserSummary(req.user.id);
+
+    const referral = await JobReferral.findById(id);
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const isOwner = referral.postedBy.toString() === req.user.id;
+    const isAdmin = currentUser?.type === 'admin';
+    if (!isOwner && !isAdmin) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+
+    if (referral.status === 'closed' || referral.status === 'filled') {
+      return res.status(400).json({ message: 'Referral is already closed' });
+    }
+
+    referral.status = 'closed';
+
+    appendTimelineEvent(referral, {
+      action: 'closed',
+      status: 'closed',
+      scope: 'referral',
+      actor: currentUser,
+      actorName: currentUser?.name,
+      actorType: currentUser?.type,
+      details: 'Referral closed'
+    });
+
+    await referral.save();
+
+    res.json({
+      message: 'Referral closed successfully',
+      referral
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 // Get my referrals (posted by me)
 async function getMyReferrals(req, res, next) {
   try {
@@ -239,7 +405,9 @@ module.exports = {
   applyForReferral,
   acceptReferral,
   rejectReferral,
+  closeReferral,
   getMyReferrals,
-  getReferralById
+  getReferralById,
+  getReferralTimeline
 };
 

--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -1,4 +1,4 @@
-const { JobReferral, User, Badge, UserBadge } = require('../models/Index');
+const { JobReferral, User, Badge, UserBadge, ReferralMessage } = require('../models/Index');
 const logger = require('../utils/logger');
 
 async function getCurrentUserSummary(userId) {
@@ -22,6 +22,30 @@ function appendTimelineEvent(referral, event) {
     applicantName: event.applicantName,
     details: event.details
   });
+}
+
+async function getReferralAccess(referralId, userId) {
+  const referral = await JobReferral.findById(referralId)
+    .populate('postedBy', 'name email alumnus_bio')
+    .populate('applicants.user', 'name email alumnus_bio');
+
+  if (!referral) {
+    return { referral: null, access: false, currentUser: null, isOwner: false, isApplicant: false };
+  }
+
+  const currentUser = await getCurrentUserSummary(userId);
+  const isOwner = referral.postedBy?._id?.toString() === userId;
+  const isApplicant = referral.applicants?.some((applicant) => applicant.user?._id?.toString() === userId);
+  const isAdmin = currentUser?.type === 'admin';
+
+  return {
+    referral,
+    currentUser,
+    access: Boolean(isOwner || isApplicant || isAdmin),
+    isOwner,
+    isApplicant,
+    isAdmin
+  };
 }
 
 // Create a new job referral opportunity
@@ -386,6 +410,113 @@ async function closeReferral(req, res, next) {
   }
 }
 
+async function getReferralMessages(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { referral, access } = await getReferralAccess(id, req.user.id);
+
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    if (!access) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+
+    const messages = await ReferralMessage.find({ referralId: id })
+      .populate('sender', 'name email alumnus_bio')
+      .populate('recipient', 'name email alumnus_bio')
+      .sort({ createdAt: 1 });
+
+    res.json({ messages });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function sendReferralMessage(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { body, recipientId } = req.body;
+    const { referral, currentUser, access, isOwner, isApplicant } = await getReferralAccess(id, req.user.id);
+
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    if (!access) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+
+    const trimmedBody = String(body || '').trim();
+    if (!trimmedBody) {
+      return res.status(400).json({ message: 'Message body is required' });
+    }
+
+    let recipientUser = null;
+
+    if (isOwner) {
+      if (!recipientId) {
+        return res.status(400).json({ message: 'Recipient is required for poster messages' });
+      }
+
+      const applicant = referral.applicants.find((entry) => entry.user?._id?.toString() === recipientId);
+      if (!applicant) {
+        return res.status(400).json({ message: 'Recipient must be an applicant on this referral' });
+      }
+
+      recipientUser = applicant.user;
+    } else if (isApplicant) {
+      recipientUser = referral.postedBy;
+    } else if (currentUser?.type === 'admin') {
+      if (!recipientId) {
+        return res.status(400).json({ message: 'Recipient is required for admin messages' });
+      }
+
+      const posterId = referral.postedBy?._id?.toString() || referral.postedBy?.toString();
+      if (recipientId === posterId) {
+        recipientUser = referral.postedBy;
+      } else {
+        const applicant = referral.applicants.find((entry) => entry.user?._id?.toString() === recipientId);
+        if (!applicant) {
+          return res.status(400).json({ message: 'Recipient must belong to this referral' });
+        }
+        recipientUser = applicant.user;
+      }
+    }
+
+    if (!recipientUser?._id && !recipientUser?.toString) {
+      return res.status(400).json({ message: 'Unable to resolve recipient' });
+    }
+
+    const message = await ReferralMessage.create({
+      referralId: id,
+      sender: req.user.id,
+      recipient: recipientUser._id || recipientUser,
+      body: trimmedBody
+    });
+
+    const populatedMessage = await ReferralMessage.findById(message._id)
+      .populate('sender', 'name email alumnus_bio')
+      .populate('recipient', 'name email alumnus_bio');
+
+    const io = req.app.get('io');
+    if (io) {
+      io.to(`referral:${id}`).emit('referralMessageCreated', {
+        referralId: id,
+        message: populatedMessage
+      });
+    }
+
+    res.status(201).json({
+      message: 'Message sent successfully',
+      data: populatedMessage
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 // Get my referrals (posted by me)
 async function getMyReferrals(req, res, next) {
   try {
@@ -406,6 +537,8 @@ module.exports = {
   acceptReferral,
   rejectReferral,
   closeReferral,
+  getReferralMessages,
+  sendReferralMessage,
   getMyReferrals,
   getReferralById,
   getReferralTimeline

--- a/backend/models/Index.js
+++ b/backend/models/Index.js
@@ -15,6 +15,7 @@ const MentorshipMatch = require('./MentorshipMatch.model');
 const MentorshipSession = require('./MentorshipSession.model');
 const MentorshipMessage = require('./MentorshipMessage.model');
 const JobReferral = require('./JobReferral.model');
+const ReferralMessage = require('./ReferralMessage.model');
 const JobSubscription = require('./JobSubscription.model');
 const Otp = require('./Otp.model');
 const BlacklistedToken = require('./BlacklistedToken.model');
@@ -49,6 +50,7 @@ module.exports = {
   MentorshipSession,
   MentorshipMessage,
   JobReferral,
+  ReferralMessage,
   JobSubscription,
   Otp,
   BlacklistedToken,

--- a/backend/models/JobReferral.model.js
+++ b/backend/models/JobReferral.model.js
@@ -1,5 +1,51 @@
 const mongoose = require('mongoose');
 
+const referralTimelineSchema = new mongoose.Schema({
+  action: {
+    type: String,
+    enum: ['posted', 'applied', 'accepted', 'rejected', 'filled', 'closed'],
+    required: true
+  },
+  status: {
+    type: String,
+    enum: ['open', 'pending', 'accepted', 'rejected', 'filled', 'closed'],
+    required: true
+  },
+  scope: {
+    type: String,
+    enum: ['referral', 'applicant'],
+    default: 'referral'
+  },
+  timestamp: {
+    type: Date,
+    default: Date.now
+  },
+  actor: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  actorName: {
+    type: String,
+    trim: true
+  },
+  actorType: {
+    type: String,
+    trim: true
+  },
+  applicant: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  applicantName: {
+    type: String,
+    trim: true
+  },
+  details: {
+    type: String,
+    trim: true
+  }
+}, { _id: false });
+
 // JobReferral Schema for standalone referral opportunities
 const jobReferralSchema = new mongoose.Schema({
   jobTitle: {
@@ -40,6 +86,7 @@ const jobReferralSchema = new mongoose.Schema({
       default: 'pending'
     }
   }],
+  timeline: [referralTimelineSchema],
   status: {
     type: String,
     enum: ['open', 'closed', 'filled'],

--- a/backend/models/ReferralMessage.model.js
+++ b/backend/models/ReferralMessage.model.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const referralMessageSchema = new mongoose.Schema({
+  referralId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'JobReferral',
+    required: true,
+    index: true
+  },
+  sender: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  recipient: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  body: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 4000
+  }
+}, {
+  timestamps: true
+});
+
+referralMessageSchema.index({ referralId: 1, createdAt: 1 });
+referralMessageSchema.index({ referralId: 1, sender: 1, createdAt: 1 });
+referralMessageSchema.index({ referralId: 1, recipient: 1, createdAt: 1 });
+
+module.exports = mongoose.model('ReferralMessage', referralMessageSchema);

--- a/backend/routes/referral.routes.js
+++ b/backend/routes/referral.routes.js
@@ -5,9 +5,12 @@ const {
   applyForReferral,
   acceptReferral,
   rejectReferral,
-  getMyReferrals
+  closeReferral,
+  getMyReferrals,
+  getReferralById,
+  getReferralTimeline
 } = require('../controllers/referral.controller');
-const { authenticate } = require('../middlewares/auth.middleware');
+const { authenticate, isStudent } = require('../middlewares/auth.middleware');
 
 const router = express.Router();
 
@@ -18,17 +21,23 @@ router.post('/', authenticate, createReferral);
 router.get('/', authenticate, getReferrals);
 
 // Apply for referral
-router.post('/:id/apply', authenticate, applyForReferral);
+router.post('/:id/apply', authenticate, isStudent, applyForReferral);
 
 // Manage applicants (only poster)
 router.put('/:id/applicants/:applicantId/accept', authenticate, acceptReferral);
 router.put('/:id/applicants/:applicantId/reject', authenticate, rejectReferral);
 
-// Get single referral
-router.get('/:id', authenticate, getReferralById);
+// Close referral (poster/admin)
+router.patch('/:id/close', authenticate, closeReferral);
+
+// Get referral timeline
+router.get('/:id/timeline', authenticate, getReferralTimeline);
 
 // Get my referrals
 router.get('/my-referrals', authenticate, getMyReferrals);
+
+// Get single referral
+router.get('/:id', authenticate, getReferralById);
 
 module.exports = router;
 

--- a/backend/routes/referral.routes.js
+++ b/backend/routes/referral.routes.js
@@ -6,6 +6,8 @@ const {
   acceptReferral,
   rejectReferral,
   closeReferral,
+  getReferralMessages,
+  sendReferralMessage,
   getMyReferrals,
   getReferralById,
   getReferralTimeline
@@ -22,6 +24,10 @@ router.get('/', authenticate, getReferrals);
 
 // Apply for referral
 router.post('/:id/apply', authenticate, isStudent, applyForReferral);
+
+// Referral Q&A / messaging
+router.post('/:id/messages', authenticate, sendReferralMessage);
+router.get('/:id/messages', authenticate, getReferralMessages);
 
 // Manage applicants (only poster)
 router.put('/:id/applicants/:applicantId/accept', authenticate, acceptReferral);

--- a/backend/server.js
+++ b/backend/server.js
@@ -201,6 +201,8 @@ const io = socketIO(server, {
   transports: ['websocket', 'polling']
 });
 
+app.set('io', io);
+
 // Initialize socket event handlers
 initializeSocket(io);
 

--- a/frontend/src/components/ReferralDetail.jsx
+++ b/frontend/src/components/ReferralDetail.jsx
@@ -6,13 +6,16 @@ import { toast } from 'react-toastify';
 
 const ReferralDetail = () => {
   const { id } = useParams();
-  const { user } = useAuth();
   const navigate = useNavigate();
+  const { isAuthReady } = useAuth();
   const [referral, setReferral] = useState(null);
+  const [timeline, setTimeline] = useState([]);
   const [loading, setLoading] = useState(true);
   const [applying, setApplying] = useState(false);
-  const [isOwner, setIsOwner] = useState(false);
   const [applicants, setApplicants] = useState([]);
+
+  const currentUserId = localStorage.getItem('user_id');
+  const currentUserType = (localStorage.getItem('user_type') || '').toLowerCase();
 
   useEffect(() => {
     fetchReferral();
@@ -21,20 +24,25 @@ const ReferralDetail = () => {
   const fetchReferral = async () => {
     try {
       setLoading(true);
-      const response = await apiClient.get(`/api/referrals/${id}?populate=true`);
-      const data = response.data;
+      const [referralResponse, timelineResponse] = await Promise.all([
+        apiClient.get(`/api/referrals/${id}`),
+        apiClient.get(`/api/referrals/${id}/timeline`)
+      ]);
+
+      const data = referralResponse.data;
       setReferral(data);
       setApplicants(data.applicants || []);
-      setIsOwner(user && data.postedBy?._id === user.id);
+      setTimeline(timelineResponse.data?.timeline || []);
     } catch (err) {
       toast.error('Failed to load referral details');
+      setTimeline([]);
     } finally {
       setLoading(false);
     }
   };
 
   const handleApply = async () => {
-    if (!user) {
+    if (!currentUserId) {
       toast.error('Please login to apply');
       return;
     }
@@ -95,9 +103,34 @@ const ReferralDetail = () => {
   }
 
   const canApply = referral.status === 'open' && 
-    !referral.applicants?.some(app => app.user._id === user?.id) &&
-    user && 
-    !isOwner;
+    !referral.applicants?.some(app => (app.user?._id || app.user?.id || app.user) === currentUserId) &&
+    currentUserId && 
+    currentUserType === 'student' &&
+    (referral.postedBy?._id || referral.postedBy?.id || referral.postedBy) !== currentUserId;
+
+  const isOwner = Boolean(
+    currentUserId && (referral.postedBy?._id || referral.postedBy?.id || referral.postedBy) === currentUserId
+  );
+
+  const describeTimelineEvent = (event) => {
+    const actionMap = {
+      posted: 'Referral posted',
+      applied: 'Application submitted',
+      accepted: 'Applicant accepted',
+      rejected: 'Applicant rejected',
+      filled: 'Referral filled',
+      closed: 'Referral closed'
+    };
+
+    return actionMap[event.action] || event.action;
+  };
+
+  const timelineTone = (event) => {
+    if (event.status === 'accepted' || event.status === 'filled') return 'from-green-500 to-emerald-600';
+    if (event.status === 'rejected' || event.status === 'closed') return 'from-red-500 to-rose-600';
+    if (event.status === 'pending') return 'from-yellow-500 to-amber-500';
+    return 'from-blue-500 to-cyan-500';
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">
@@ -152,6 +185,54 @@ const ReferralDetail = () => {
               </div>
             </div>
 
+            {/* Timeline */}
+            <div className="bg-white rounded-2xl shadow-lg p-8 mb-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-900">Status Timeline</h2>
+                <span className="text-sm text-gray-500">Chronological activity feed</span>
+              </div>
+              {timeline.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-gray-200 p-6 text-gray-500">
+                  No timeline events yet.
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {timeline.map((event, index) => (
+                    <div key={`${event.timestamp}-${index}`} className="flex gap-4">
+                      <div className={`mt-1 h-3 w-3 rounded-full bg-gradient-to-r ${timelineTone(event)} shadow-sm`} />
+                      <div className="flex-1 pb-4 border-b border-gray-100 last:border-b-0">
+                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                          <div>
+                            <p className="font-semibold text-gray-900">{describeTimelineEvent(event)}</p>
+                            <p className="text-sm text-gray-600">
+                              {event.actorName ? `by ${event.actorName}` : 'System'}
+                              {event.applicantName ? ` for ${event.applicantName}` : ''}
+                            </p>
+                          </div>
+                          <div className="text-sm text-gray-500">
+                            {event.timestamp ? new Date(event.timestamp).toLocaleString() : ''}
+                          </div>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-700">
+                            {String(event.status || '').toUpperCase()}
+                          </span>
+                          {event.scope && (
+                            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-blue-50 text-blue-700">
+                              {event.scope}
+                            </span>
+                          )}
+                        </div>
+                        {event.details && (
+                          <p className="mt-3 text-sm text-gray-600">{event.details}</p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
             {/* Apply Section */}
             {canApply && (
               <div className="bg-gradient-to-r from-green-500 to-emerald-600 rounded-2xl p-8 shadow-2xl mb-8">
@@ -174,7 +255,7 @@ const ReferralDetail = () => {
               </div>
             )}
 
-            {!user && (
+            {!currentUserId && (
               <div className="bg-yellow-50 border border-yellow-200 rounded-2xl p-8 mb-8">
                 <h3 className="text-xl font-bold text-yellow-900 mb-4">Login to Apply</h3>
                 <p className="text-yellow-800 mb-6">Sign in to your account to apply for this referral opportunity and track your applications.</p>

--- a/frontend/src/components/ReferralDetail.jsx
+++ b/frontend/src/components/ReferralDetail.jsx
@@ -10,6 +10,10 @@ const ReferralDetail = () => {
   const { isAuthReady } = useAuth();
   const [referral, setReferral] = useState(null);
   const [timeline, setTimeline] = useState([]);
+  const [messages, setMessages] = useState([]);
+  const [messageBody, setMessageBody] = useState('');
+  const [selectedRecipientId, setSelectedRecipientId] = useState('');
+  const [sendingMessage, setSendingMessage] = useState(false);
   const [loading, setLoading] = useState(true);
   const [applying, setApplying] = useState(false);
   const [applicants, setApplicants] = useState([]);
@@ -17,9 +21,47 @@ const ReferralDetail = () => {
   const currentUserId = localStorage.getItem('user_id');
   const currentUserType = (localStorage.getItem('user_type') || '').toLowerCase();
 
+  const getDocId = (value) => value?._id || value?.id || value;
+
+  const getCurrentConversationRecipient = () => {
+    if (!referral) {
+      return '';
+    }
+
+    if (isOwner) {
+      return selectedRecipientId || getDocId(applicants[0]?.user) || '';
+    }
+
+    return getDocId(referral.postedBy) || '';
+  };
+
+  const isOwner = Boolean(
+    currentUserId && getDocId(referral?.postedBy) === currentUserId
+  );
+
+  const isApplicant = Boolean(
+    currentUserId && applicants.some((applicant) => getDocId(applicant.user) === currentUserId)
+  );
+
+  const canMessage = Boolean(currentUserId && (isOwner || isApplicant));
+
   useEffect(() => {
     fetchReferral();
   }, [id]);
+
+  useEffect(() => {
+    if (!referral) {
+      return;
+    }
+
+    if (isOwner && applicants.length > 0 && !selectedRecipientId) {
+      setSelectedRecipientId(getDocId(applicants[0].user));
+    }
+
+    if (!isOwner) {
+      setSelectedRecipientId(getDocId(referral.postedBy));
+    }
+  }, [referral, applicants, isOwner, selectedRecipientId]);
 
   const fetchReferral = async () => {
     try {
@@ -33,11 +75,33 @@ const ReferralDetail = () => {
       setReferral(data);
       setApplicants(data.applicants || []);
       setTimeline(timelineResponse.data?.timeline || []);
+
+      if (currentUserId && (getDocId(data.postedBy) === currentUserId || (data.applicants || []).some((applicant) => getDocId(applicant.user) === currentUserId))) {
+        const messagesResponse = await apiClient.get(`/api/referrals/${id}/messages`);
+        setMessages(messagesResponse.data?.messages || []);
+      } else {
+        setMessages([]);
+      }
     } catch (err) {
       toast.error('Failed to load referral details');
       setTimeline([]);
+      setMessages([]);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchMessages = async () => {
+    try {
+      if (!canMessage) {
+        setMessages([]);
+        return;
+      }
+
+      const response = await apiClient.get(`/api/referrals/${id}/messages`);
+      setMessages(response.data?.messages || []);
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to load referral messages');
     }
   };
 
@@ -76,6 +140,37 @@ const ReferralDetail = () => {
       fetchReferral();
     } catch (err) {
       toast.error('Failed to reject applicant');
+    }
+  };
+
+  const handleSendMessage = async (event) => {
+    event.preventDefault();
+
+    const trimmedBody = messageBody.trim();
+    if (!trimmedBody) {
+      toast.error('Enter a message before sending');
+      return;
+    }
+
+    const recipientId = getCurrentConversationRecipient();
+    if (isOwner && !recipientId) {
+      toast.error('Select an applicant to message');
+      return;
+    }
+
+    try {
+      setSendingMessage(true);
+      await apiClient.post(`/api/referrals/${id}/messages`, {
+        body: trimmedBody,
+        ...(isOwner ? { recipientId } : {})
+      });
+      setMessageBody('');
+      await fetchMessages();
+      toast.success('Message sent');
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to send message');
+    } finally {
+      setSendingMessage(false);
     }
   };
 
@@ -131,6 +226,8 @@ const ReferralDetail = () => {
     if (event.status === 'pending') return 'from-yellow-500 to-amber-500';
     return 'from-blue-500 to-cyan-500';
   };
+
+  const getMessageSide = (message) => getDocId(message.sender) === currentUserId ? 'self' : 'other';
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">
@@ -229,6 +326,101 @@ const ReferralDetail = () => {
                       </div>
                     </div>
                   ))}
+                </div>
+              )}
+            </div>
+
+            {/* Messaging */}
+            <div className="bg-white rounded-2xl shadow-lg p-8 mb-8">
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <h2 className="text-2xl font-bold text-gray-900">Candidate Q&amp;A</h2>
+                  <p className="text-sm text-gray-500 mt-1">Private clarification thread for the poster and applicants</p>
+                </div>
+                {canMessage && (
+                  <button
+                    type="button"
+                    onClick={fetchMessages}
+                    className="text-sm font-semibold text-blue-600 hover:text-blue-800"
+                  >
+                    Refresh
+                  </button>
+                )}
+              </div>
+
+              {!canMessage ? (
+                <div className="rounded-xl border border-dashed border-gray-200 p-6 text-gray-500">
+                  Only the referral poster and applicants can exchange messages here.
+                </div>
+              ) : (
+                <div className="grid gap-6">
+                  <div className="max-h-80 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 p-4 space-y-3">
+                    {messages.length === 0 ? (
+                      <div className="rounded-xl border border-dashed border-gray-200 bg-white p-6 text-gray-500">
+                        No messages yet. Start the conversation below.
+                      </div>
+                    ) : (
+                      messages.map((message) => {
+                        const side = getMessageSide(message);
+                        return (
+                          <div
+                            key={message._id}
+                            className={`flex ${side === 'self' ? 'justify-end' : 'justify-start'}`}
+                          >
+                            <div className={`max-w-[85%] rounded-2xl px-4 py-3 shadow-sm ${side === 'self' ? 'bg-blue-600 text-white' : 'bg-white text-gray-800 border border-gray-200'}`}>
+                              <div className="flex items-center justify-between gap-4 mb-2 text-xs opacity-80">
+                                <span className="font-semibold">
+                                  {getDocId(message.sender) === currentUserId ? 'You' : message.sender?.name || 'Member'}
+                                  {' '}→{' '}
+                                  {message.recipient?.name || 'Recipient'}
+                                </span>
+                                <span>{message.createdAt ? new Date(message.createdAt).toLocaleString() : ''}</span>
+                              </div>
+                              <p className="whitespace-pre-wrap leading-relaxed">{message.body}</p>
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+
+                  <form onSubmit={handleSendMessage} className="space-y-4">
+                    {isOwner && applicants.length > 0 && (
+                      <div>
+                        <label className="block text-sm font-semibold text-gray-700 mb-2">Reply to applicant</label>
+                        <select
+                          value={selectedRecipientId}
+                          onChange={(e) => setSelectedRecipientId(e.target.value)}
+                          className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                        >
+                          {applicants.map((applicant) => (
+                            <option key={getDocId(applicant.user)} value={getDocId(applicant.user)}>
+                              {applicant.user?.name || 'Applicant'} - {applicant.status.toUpperCase()}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
+
+                    <div>
+                      <label className="block text-sm font-semibold text-gray-700 mb-2">Message</label>
+                      <textarea
+                        rows="4"
+                        value={messageBody}
+                        onChange={(e) => setMessageBody(e.target.value)}
+                        placeholder={isOwner ? 'Ask a question or reply to an applicant...' : 'Ask the poster a clarification question...'}
+                        className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 resize-none"
+                      />
+                    </div>
+
+                    <button
+                      type="submit"
+                      disabled={sendingMessage}
+                      className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white shadow-lg transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {sendingMessage ? 'Sending...' : 'Send Message'}
+                    </button>
+                  </form>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Implemented referral Q&A messaging. The backend now has a dedicated ReferralMessage model and participant-gated endpoints for posting and fetching messages on a referral, with optional Socket.IO emits wired through server.js and referral.controller.js. The route additions are in referral.routes.js, and the model is exported from Index.js.

The referral detail page now includes a message panel with conversation history, a composer, and recipient selection for the poster when there are multiple applicants in ReferralDetail.jsx. Applicants can message the poster directly; the poster can reply to a specific applicant from the dropdown. I validated the edited files with `get_errors` and a module-load check, and both passed.

One note: the backend is live-ready for Socket.IO message events, but the app root is not currently mounting `SocketProvider`, so the UI uses HTTP refreshes rather than live push updates. If you want, I can wire the existing socket context into the app and subscribe the referral panel to live message events next.


closes #202