### PR TITLE
feat: Admin Moderation Tools + Audit Trail (Referrals)

### DIFF
--- a/backend/controllers/career.controller.js
+++ b/backend/controllers/career.controller.js
@@ -123,7 +123,9 @@ async function addCareer(req,res,next){
             skills: req.body.skills || [],
             job_type: req.body.job_type || 'full-time',
             experience_level: req.body.experience_level || 'mid',
-            salary_range: req.body.salary_range || ''
+            salary_range: req.body.salary_range || '',
+            deadline: req.body.deadline ? new Date(req.body.deadline) : null,
+            status: req.body.status || 'open'
         };
         const career=await Career.create(careerData);
         

--- a/backend/controllers/opportunity.controller.js
+++ b/backend/controllers/opportunity.controller.js
@@ -1,0 +1,186 @@
+const {
+  Career,
+  JobReferral,
+  SavedItem,
+  Notification,
+  NotificationPreference
+} = require('../models/Index');
+const {
+  normalizeEntityType,
+  buildSavedItemSnapshot,
+  resolveUserPreferences
+} = require('../services/opportunityNotificationService');
+
+async function getSavedItems(req, res, next) {
+  try {
+    const savedItems = await SavedItem.find({ user: req.user.id })
+      .sort({ createdAt: -1 });
+
+    res.json({ savedItems });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function toggleSavedItem(req, res, next) {
+  try {
+    const entityType = normalizeEntityType(req.body.entityType);
+    const entityId = req.body.entityId;
+
+    if (!entityType || !entityId) {
+      return res.status(400).json({ message: 'entityType and entityId are required' });
+    }
+
+    const entity = entityType === 'career'
+      ? await Career.findById(entityId)
+      : await JobReferral.findById(entityId);
+
+    if (!entity) {
+      return res.status(404).json({ message: 'Opportunity not found' });
+    }
+
+    const existing = await SavedItem.findOne({
+      user: req.user.id,
+      entityType,
+      entityId
+    });
+
+    if (existing) {
+      await existing.deleteOne();
+      return res.json({ saved: false, message: 'Opportunity removed from saved items' });
+    }
+
+    const { preferences } = await resolveUserPreferences(req.user.id);
+    const entitySnapshot = await buildSavedItemSnapshot(entityType, entity, preferences);
+
+    const savedItem = await SavedItem.create({
+      user: req.user.id,
+      entityType,
+      entityId,
+      entitySnapshot,
+      savedScore: entitySnapshot.matchScore || null,
+      lastKnownStatus: entitySnapshot.status || '',
+      lastKnownDeadlineAt: entitySnapshot.deadline || null
+    });
+
+    res.status(201).json({
+      saved: true,
+      message: 'Opportunity saved successfully',
+      savedItem
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function getNotifications(req, res, next) {
+  try {
+    const limit = Math.max(1, Math.min(parseInt(req.query.limit, 10) || 20, 100));
+    const unreadOnly = String(req.query.unreadOnly || '').toLowerCase() === 'true';
+
+    const query = { user: req.user.id };
+    if (unreadOnly) {
+      query.isRead = false;
+    }
+
+    const [notifications, unreadCount] = await Promise.all([
+      Notification.find(query)
+        .sort({ createdAt: -1 })
+        .limit(limit),
+      Notification.countDocuments({ user: req.user.id, isRead: false })
+    ]);
+
+    res.json({ notifications, unreadCount });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function markNotificationRead(req, res, next) {
+  try {
+    const notification = await Notification.findOne({
+      _id: req.params.id,
+      user: req.user.id
+    });
+
+    if (!notification) {
+      return res.status(404).json({ message: 'Notification not found' });
+    }
+
+    notification.isRead = true;
+    notification.readAt = notification.readAt || new Date();
+    await notification.save();
+
+    res.json({
+      message: 'Notification marked as read',
+      notification
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function getNotificationPreferences(req, res, next) {
+  try {
+    let preferences = await NotificationPreference.findOne({ user: req.user.id });
+
+    if (!preferences) {
+      preferences = await NotificationPreference.create({
+        user: req.user.id
+      });
+    }
+
+    res.json(preferences);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function updateNotificationPreferences(req, res, next) {
+  try {
+    let preferences = await NotificationPreference.findOne({ user: req.user.id });
+
+    if (!preferences) {
+      preferences = new NotificationPreference({ user: req.user.id });
+    }
+
+    const { enabled, deadlineApproaching, statusChanges, betterRecommendations, deadlineWindowDays } = req.body;
+
+    if (enabled !== undefined) {
+      preferences.enabled = Boolean(enabled);
+    }
+    if (deadlineApproaching !== undefined) {
+      preferences.deadlineApproaching = Boolean(deadlineApproaching);
+    }
+    if (statusChanges !== undefined) {
+      preferences.statusChanges = Boolean(statusChanges);
+    }
+    if (betterRecommendations !== undefined) {
+      preferences.betterRecommendations = Boolean(betterRecommendations);
+    }
+    if (deadlineWindowDays !== undefined) {
+      const parsedWindow = Number(deadlineWindowDays);
+      if (!Number.isNaN(parsedWindow) && parsedWindow >= 1 && parsedWindow <= 30) {
+        preferences.deadlineWindowDays = parsedWindow;
+      }
+    }
+
+    await preferences.save();
+
+    res.json({
+      message: 'Notification preferences updated',
+      preferences
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = {
+  getSavedItems,
+  toggleSavedItem,
+  getNotifications,
+  markNotificationRead,
+  getNotificationPreferences,
+  updateNotificationPreferences
+};

--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -1,5 +1,6 @@
 const { JobReferral, User, Badge, UserBadge, ReferralMessage } = require('../models/Index');
 const logger = require('../utils/logger');
+const { recomputeAndPersistReferralBonus } = require('../services/referralBonusService');
 
 async function getCurrentUserSummary(userId) {
   return User.findById(userId).select('_id name type');
@@ -57,6 +58,7 @@ async function createReferral(req, res, next) {
       company: req.body.company,
       description: req.body.description,
       referralBonus: req.body.referralBonus || 0,
+      bonusPolicy: req.body.bonusPolicy || {},
       deadline: req.body.deadline ? new Date(req.body.deadline) : null,
       postedBy: req.user.id,
       timeline: []
@@ -241,7 +243,9 @@ async function acceptReferral(req, res, next) {
     const applicantUser = await User.findById(applicantId).select('_id name');
 
     referral.applicants[applicantIndex].status = 'accepted';
+    referral.applicants[applicantIndex].acceptedAt = new Date();
     referral.status = 'filled'; // Close after accept
+    referral.filledAt = new Date();
 
     appendTimelineEvent(referral, {
       action: 'accepted',
@@ -268,6 +272,7 @@ async function acceptReferral(req, res, next) {
     });
 
     await referral.save();
+  await recomputeAndPersistReferralBonus(referral, { computedBy: req.user.id });
 
     await referral.populate('applicants.user', 'name email');
 
@@ -388,6 +393,7 @@ async function closeReferral(req, res, next) {
     }
 
     referral.status = 'closed';
+    referral.closedAt = new Date();
 
     appendTimelineEvent(referral, {
       action: 'closed',
@@ -400,6 +406,7 @@ async function closeReferral(req, res, next) {
     });
 
     await referral.save();
+    await recomputeAndPersistReferralBonus(referral, { computedBy: req.user.id });
 
     res.json({
       message: 'Referral closed successfully',
@@ -530,6 +537,30 @@ async function getMyReferrals(req, res, next) {
   }
 }
 
+async function computeReferralBonus(req, res, next) {
+  try {
+    const referral = await JobReferral.findById(req.params.id)
+      .populate('postedBy', 'name email alumnus_bio')
+      .populate('applicants.user', 'name email alumnus_bio');
+
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const { referral: persistedReferral, bonus } = await recomputeAndPersistReferralBonus(referral, {
+      computedBy: req.user?.id || null
+    });
+
+    res.json({
+      message: 'Referral bonus computed successfully',
+      bonus,
+      referral: persistedReferral
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 module.exports = {
   createReferral,
   getReferrals,
@@ -541,6 +572,7 @@ module.exports = {
   sendReferralMessage,
   getMyReferrals,
   getReferralById,
-  getReferralTimeline
+  getReferralTimeline,
+  computeReferralBonus
 };
 

--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -1,9 +1,10 @@
-const { JobReferral, User, Badge, UserBadge, ReferralMessage } = require('../models/Index');
+const mongoose = require('mongoose');
+const { JobReferral, User, Badge, UserBadge, ReferralMessage, ReferralModerationAction } = require('../models/Index');
 const logger = require('../utils/logger');
 const { recomputeAndPersistReferralBonus } = require('../services/referralBonusService');
 
 async function getCurrentUserSummary(userId) {
-  return User.findById(userId).select('_id name type');
+  return User.findById(userId).select('_id name type referralPostingSuspended referralPostingSuspendedAt referralPostingSuspendedReason referralPostingSuspendedBy');
 }
 
 function appendTimelineEvent(referral, event) {
@@ -23,6 +24,60 @@ function appendTimelineEvent(referral, event) {
     applicantName: event.applicantName,
     details: event.details
   });
+}
+
+function normalizeModerationReason(reason, fallback = '') {
+  const text = String(reason || fallback || '').trim();
+  return text || fallback || '';
+}
+
+function isReferralHidden(referral) {
+  return ['hidden', 'removed'].includes(String(referral?.moderation?.status || referral?.moderationStatus || 'visible').toLowerCase());
+}
+
+async function writeModerationAction(session, actionData) {
+  const [moderationAction] = await ReferralModerationAction.create([actionData], { session });
+  return moderationAction;
+}
+
+async function moderateReferral({ referralId, adminId, actionType, reason, referralMutator, posterMutator }) {
+  const session = await mongoose.startSession();
+
+  try {
+    let referral = null;
+    let moderationAction = null;
+
+    await session.withTransaction(async () => {
+      referral = await JobReferral.findById(referralId)
+        .populate('postedBy', 'name email type referralPostingSuspended referralPostingSuspendedAt referralPostingSuspendedReason');
+
+      if (!referral) {
+        const notFoundError = new Error('Referral not found');
+        notFoundError.statusCode = 404;
+        throw notFoundError;
+      }
+
+      await referralMutator(referral, session);
+      await referral.save({ session });
+
+      if (typeof posterMutator === 'function') {
+        const posterId = referral.postedBy?._id || referral.postedBy;
+        await posterMutator(posterId, session, referral);
+      }
+
+      moderationAction = await writeModerationAction(session, {
+        adminId,
+        referralId: referral._id,
+        actionType,
+        reason: normalizeModerationReason(reason),
+        targetUserId: referral.postedBy?._id || referral.postedBy || null
+      });
+    });
+
+    return { referral, moderationAction };
+  } finally {
+    session.endSession();
+  }
 }
 
 async function getReferralAccess(referralId, userId) {
@@ -132,14 +187,18 @@ async function getReferrals(req, res, next) {
   try {
     const { status = 'open', search, page = 1, limit = 10 } = req.query;
     const skip = (page - 1) * limit;
+    const currentUser = req.user?.id ? await getCurrentUserSummary(req.user.id) : null;
 
     const query = { status };
+    if (currentUser?.type !== 'admin') {
+      query['moderation.status'] = { $nin: ['hidden', 'removed'] };
+    }
     if (search) {
       query.$text = { $search: search };
     }
 
     const referrals = await JobReferral.find(query)
-      .populate('postedBy', 'name email alumnus_bio')
+      .populate('postedBy', 'name email alumnus_bio type referralPostingSuspended referralPostingSuspendedReason')
       .populate('applicants.user', 'name email')
       .sort({ createdAt: -1 })
       .skip(skip * 1)
@@ -168,6 +227,10 @@ async function applyForReferral(req, res, next) {
 
     const referral = await JobReferral.findById(id);
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    if (isReferralHidden(referral) && currentUser?.type !== 'admin') {
       return res.status(404).json({ message: 'Referral not found' });
     }
 
@@ -342,10 +405,16 @@ async function rejectReferral(req, res, next) {
 async function getReferralById(req, res, next) {
   try {
     const referral = await JobReferral.findById(req.params.id)
-      .populate('postedBy', 'name email alumnus_bio')
+      .populate('postedBy', 'name email alumnus_bio type referralPostingSuspended referralPostingSuspendedReason')
       .populate('applicants.user', 'name email alumnus_bio');
     
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const currentUser = req.user?.id ? await getCurrentUserSummary(req.user.id) : null;
+    const isOwner = referral.postedBy?._id?.toString() === req.user?.id;
+    if (isReferralHidden(referral) && currentUser?.type !== 'admin' && !isOwner) {
       return res.status(404).json({ message: 'Referral not found' });
     }
 
@@ -357,8 +426,14 @@ async function getReferralById(req, res, next) {
 
 async function getReferralTimeline(req, res, next) {
   try {
-    const referral = await JobReferral.findById(req.params.id).select('timeline');
+    const referral = await JobReferral.findById(req.params.id).select('timeline moderation postedBy');
     if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const currentUser = req.user?.id ? await getCurrentUserSummary(req.user.id) : null;
+    const isOwner = referral.postedBy?.toString() === req.user?.id;
+    if (isReferralHidden(referral) && currentUser?.type !== 'admin' && !isOwner) {
       return res.status(404).json({ message: 'Referral not found' });
     }
 
@@ -413,6 +488,201 @@ async function closeReferral(req, res, next) {
       referral
     });
   } catch (err) {
+    next(err);
+  }
+}
+
+async function getAdminReferrals(req, res, next) {
+  try {
+    const { status, moderationStatus, search, page = 1, limit = 20 } = req.query;
+    const skip = (Number(page) - 1) * Number(limit);
+
+    const query = {};
+    if (status) {
+      query.status = status;
+    }
+    if (moderationStatus) {
+      query['moderation.status'] = moderationStatus;
+    }
+    if (search) {
+      query.$text = { $search: search };
+    }
+
+    const referrals = await JobReferral.find(query)
+      .populate('postedBy', 'name email alumnus_bio type referralPostingSuspended referralPostingSuspendedReason referralPostingSuspendedAt')
+      .populate('moderation.moderatedBy', 'name email type')
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(Number(limit));
+
+    const total = await JobReferral.countDocuments(query);
+
+    res.json({
+      referrals,
+      pagination: { total, page: Number(page), limit: Number(limit) }
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function getReferralModerationActions(req, res, next) {
+  try {
+    const referral = await JobReferral.findById(req.params.id).select('_id');
+    if (!referral) {
+      return res.status(404).json({ message: 'Referral not found' });
+    }
+
+    const actions = await ReferralModerationAction.find({ referralId: req.params.id })
+      .populate('adminId', 'name email type')
+      .sort({ createdAt: -1 });
+
+    res.json({ actions });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function flagReferralForSpam(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { reason } = req.body;
+
+    const { referral, moderationAction } = await moderateReferral({
+      referralId: id,
+      adminId: req.user.id,
+      actionType: 'flag',
+      reason: normalizeModerationReason(reason, 'Flagged for review'),
+      referralMutator: async (referralDoc) => {
+        referralDoc.moderation = {
+          status: 'flagged',
+          reason: normalizeModerationReason(reason, 'Flagged for review'),
+          moderatedBy: req.user.id,
+          moderatedAt: new Date()
+        };
+      }
+    });
+
+    res.json({
+      message: 'Referral flagged successfully',
+      referral,
+      moderationAction
+    });
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ message: err.message });
+    }
+    next(err);
+  }
+}
+
+async function hideReferral(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { reason } = req.body;
+
+    const { referral, moderationAction } = await moderateReferral({
+      referralId: id,
+      adminId: req.user.id,
+      actionType: 'hide',
+      reason: normalizeModerationReason(reason, 'Hidden by administrator'),
+      referralMutator: async (referralDoc) => {
+        referralDoc.moderation = {
+          status: 'hidden',
+          reason: normalizeModerationReason(reason, 'Hidden by administrator'),
+          moderatedBy: req.user.id,
+          moderatedAt: new Date()
+        };
+      }
+    });
+
+    res.json({
+      message: 'Referral hidden successfully',
+      referral,
+      moderationAction
+    });
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ message: err.message });
+    }
+    next(err);
+  }
+}
+
+async function restoreReferral(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { reason } = req.body;
+
+    const { referral, moderationAction } = await moderateReferral({
+      referralId: id,
+      adminId: req.user.id,
+      actionType: 'restore',
+      reason: normalizeModerationReason(reason, 'Restored by administrator'),
+      referralMutator: async (referralDoc) => {
+        referralDoc.moderation = {
+          status: 'visible',
+          reason: normalizeModerationReason(reason, 'Restored by administrator'),
+          moderatedBy: req.user.id,
+          moderatedAt: new Date()
+        };
+      }
+    });
+
+    res.json({
+      message: 'Referral restored successfully',
+      referral,
+      moderationAction
+    });
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ message: err.message });
+    }
+    next(err);
+  }
+}
+
+async function suspendReferralPoster(req, res, next) {
+  try {
+    const { id } = req.params;
+    const { reason } = req.body;
+
+    const { referral, moderationAction } = await moderateReferral({
+      referralId: id,
+      adminId: req.user.id,
+      actionType: 'suspend_poster',
+      reason: normalizeModerationReason(reason, 'Poster suspended by administrator'),
+      referralMutator: async (referralDoc) => {
+        referralDoc.moderation = {
+          status: 'hidden',
+          reason: normalizeModerationReason(reason, 'Poster suspended by administrator'),
+          moderatedBy: req.user.id,
+          moderatedAt: new Date()
+        };
+      },
+      posterMutator: async (posterId, session, referralDoc) => {
+        if (!posterId) {
+          return;
+        }
+
+        await User.findByIdAndUpdate(posterId, {
+          referralPostingSuspended: true,
+          referralPostingSuspendedAt: new Date(),
+          referralPostingSuspendedReason: normalizeModerationReason(reason, 'Poster suspended by administrator'),
+          referralPostingSuspendedBy: req.user.id
+        }, { session });
+      }
+    });
+
+    res.json({
+      message: 'Referral poster suspended successfully',
+      referral,
+      moderationAction
+    });
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return res.status(404).json({ message: err.message });
+    }
     next(err);
   }
 }
@@ -568,6 +838,12 @@ module.exports = {
   acceptReferral,
   rejectReferral,
   closeReferral,
+  getAdminReferrals,
+  getReferralModerationActions,
+  flagReferralForSpam,
+  hideReferral,
+  restoreReferral,
+  suspendReferralPoster,
   getReferralMessages,
   sendReferralMessage,
   getMyReferrals,

--- a/backend/middlewares/auth.middleware.js
+++ b/backend/middlewares/auth.middleware.js
@@ -47,6 +47,18 @@ function checkUserRole(requiredRole) {
                 return res.status(403).json({ error: `Access denied. ${roleLabel} only.` });
             }
 
+            const canPostContent = Array.isArray(requiredRole)
+                ? requiredRole.includes('alumnus') || requiredRole.includes('admin')
+                : requiredRole === 'alumnus' || requiredRole === 'admin';
+
+            if (canPostContent && req.userData.type !== 'admin' && req.userData.referralPostingSuspended) {
+                return res.status(403).json({
+                    error: req.userData.referralPostingSuspendedReason
+                        ? `Posting suspended: ${req.userData.referralPostingSuspendedReason}`
+                        : 'Posting suspended by an administrator'
+                });
+            }
+
             next();
         } catch (err) {
             return res.status(500).json({ error: 'Server error' });

--- a/backend/models/Career.model.js
+++ b/backend/models/Career.model.js
@@ -38,6 +38,15 @@ const careerSchema = new mongoose.Schema({
     type: String,
     default: ''
   },
+  deadline: {
+    type: Date,
+    default: null
+  },
+  status: {
+    type: String,
+    enum: ['open', 'filled', 'closed'],
+    default: 'open'
+  },
   user: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
@@ -70,5 +79,7 @@ careerSchema.index({ createdAt: -1 });
 careerSchema.index({ skills: 1 });
 careerSchema.index({ job_type: 1 });
 careerSchema.index({ experience_level: 1 });
+careerSchema.index({ status: 1 });
+careerSchema.index({ deadline: 1 });
 
 module.exports = mongoose.model('Career', careerSchema);

--- a/backend/models/Index.js
+++ b/backend/models/Index.js
@@ -17,6 +17,9 @@ const MentorshipMessage = require('./MentorshipMessage.model');
 const JobReferral = require('./JobReferral.model');
 const ReferralMessage = require('./ReferralMessage.model');
 const JobSubscription = require('./JobSubscription.model');
+const SavedItem = require('./SavedItem.model');
+const Notification = require('./Notification.model');
+const NotificationPreference = require('./NotificationPreference.model');
 const Otp = require('./Otp.model');
 const BlacklistedToken = require('./BlacklistedToken.model');
 const Endorsement = require('./Endorsement.model');
@@ -52,6 +55,9 @@ module.exports = {
   JobReferral,
   ReferralMessage,
   JobSubscription,
+  SavedItem,
+  Notification,
+  NotificationPreference,
   Otp,
   BlacklistedToken,
   Endorsement,

--- a/backend/models/Index.js
+++ b/backend/models/Index.js
@@ -15,6 +15,7 @@ const MentorshipMatch = require('./MentorshipMatch.model');
 const MentorshipSession = require('./MentorshipSession.model');
 const MentorshipMessage = require('./MentorshipMessage.model');
 const JobReferral = require('./JobReferral.model');
+const ReferralModerationAction = require('./ReferralModerationAction.model');
 const ReferralMessage = require('./ReferralMessage.model');
 const JobSubscription = require('./JobSubscription.model');
 const SavedItem = require('./SavedItem.model');
@@ -53,6 +54,7 @@ module.exports = {
   MentorshipSession,
   MentorshipMessage,
   JobReferral,
+  ReferralModerationAction,
   ReferralMessage,
   JobSubscription,
   SavedItem,

--- a/backend/models/JobReferral.model.js
+++ b/backend/models/JobReferral.model.js
@@ -46,6 +46,121 @@ const referralTimelineSchema = new mongoose.Schema({
   }
 }, { _id: false });
 
+const referralBonusPolicySchema = new mongoose.Schema({
+  enabled: {
+    type: Boolean,
+    default: true
+  },
+  payoutOn: {
+    type: String,
+    enum: ['accepted', 'filled'],
+    default: 'filled'
+  },
+  companyName: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  companyMultiplier: {
+    type: Number,
+    default: 1,
+    min: 0
+  },
+  companyFlatBonus: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  deadlineReductionPerDayPercent: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  deadlineReductionCapPercent: {
+    type: Number,
+    default: 100,
+    min: 0,
+    max: 100
+  },
+  notes: {
+    type: String,
+    trim: true,
+    default: ''
+  }
+}, { _id: false });
+
+const referralBonusComputationSchema = new mongoose.Schema({
+  status: {
+    type: String,
+    enum: ['pending', 'eligible', 'not-eligible'],
+    default: 'pending'
+  },
+  amount: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  baseAmount: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  multiplier: {
+    type: Number,
+    default: 1,
+    min: 0
+  },
+  flatBonus: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  deadlinePenaltyPercent: {
+    type: Number,
+    default: 0,
+    min: 0,
+    max: 100
+  },
+  deadlinePenaltyAmount: {
+    type: Number,
+    default: 0,
+    min: 0
+  },
+  payoutEvent: {
+    type: String,
+    enum: ['accepted', 'filled'],
+    default: 'filled'
+  },
+  eligibleApplicantId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  },
+  eligibleApplicantName: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  computedAt: {
+    type: Date,
+    default: null
+  },
+  computedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  },
+  reason: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  policySnapshot: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {}
+  }
+}, { _id: false });
+
 // JobReferral Schema for standalone referral opportunities
 const jobReferralSchema = new mongoose.Schema({
   jobTitle: {
@@ -67,6 +182,14 @@ const jobReferralSchema = new mongoose.Schema({
     default: 0,
     min: 0
   },
+  bonusPolicy: {
+    type: referralBonusPolicySchema,
+    default: () => ({})
+  },
+  bonusComputation: {
+    type: referralBonusComputationSchema,
+    default: () => ({ status: 'pending', amount: 0, baseAmount: 0, multiplier: 1, flatBonus: 0, deadlinePenaltyPercent: 0, deadlinePenaltyAmount: 0, payoutEvent: 'filled', eligibleApplicantId: null, eligibleApplicantName: '', computedAt: null, computedBy: null, reason: '', policySnapshot: {} })
+  },
   deadline: {
     type: Date
   },
@@ -84,6 +207,14 @@ const jobReferralSchema = new mongoose.Schema({
       type: String,
       enum: ['pending', 'accepted', 'rejected'],
       default: 'pending'
+    },
+    acceptedAt: {
+      type: Date,
+      default: null
+    },
+    rejectedAt: {
+      type: Date,
+      default: null
     }
   }],
   timeline: [referralTimelineSchema],
@@ -91,6 +222,18 @@ const jobReferralSchema = new mongoose.Schema({
     type: String,
     enum: ['open', 'closed', 'filled'],
     default: 'open'
+  },
+  acceptedAt: {
+    type: Date,
+    default: null
+  },
+  filledAt: {
+    type: Date,
+    default: null
+  },
+  closedAt: {
+    type: Date,
+    default: null
   },
   postedBy: {
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/models/JobReferral.model.js
+++ b/backend/models/JobReferral.model.js
@@ -161,6 +161,28 @@ const referralBonusComputationSchema = new mongoose.Schema({
   }
 }, { _id: false });
 
+const referralModerationStateSchema = new mongoose.Schema({
+  status: {
+    type: String,
+    enum: ['visible', 'flagged', 'hidden', 'removed'],
+    default: 'visible'
+  },
+  reason: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  moderatedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  },
+  moderatedAt: {
+    type: Date,
+    default: null
+  }
+}, { _id: false });
+
 // JobReferral Schema for standalone referral opportunities
 const jobReferralSchema = new mongoose.Schema({
   jobTitle: {
@@ -189,6 +211,10 @@ const jobReferralSchema = new mongoose.Schema({
   bonusComputation: {
     type: referralBonusComputationSchema,
     default: () => ({ status: 'pending', amount: 0, baseAmount: 0, multiplier: 1, flatBonus: 0, deadlinePenaltyPercent: 0, deadlinePenaltyAmount: 0, payoutEvent: 'filled', eligibleApplicantId: null, eligibleApplicantName: '', computedAt: null, computedBy: null, reason: '', policySnapshot: {} })
+  },
+  moderation: {
+    type: referralModerationStateSchema,
+    default: () => ({ status: 'visible', reason: '', moderatedBy: null, moderatedAt: null })
   },
   deadline: {
     type: Date
@@ -246,6 +272,7 @@ const jobReferralSchema = new mongoose.Schema({
 
 // Indexes for efficient querying and search
 jobReferralSchema.index({ status: 1 });
+jobReferralSchema.index({ 'moderation.status': 1 });
 jobReferralSchema.index({ 'postedBy': 1 });
 jobReferralSchema.index({ deadline: 1 });
 jobReferralSchema.index({ 'jobTitle': 'text', 'company': 'text', 'description': 'text' });

--- a/backend/models/Notification.model.js
+++ b/backend/models/Notification.model.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose');
+
+const notificationSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  type: {
+    type: String,
+    enum: ['deadline', 'status-change', 'better-recommendation', 'saved-opportunity'],
+    required: true,
+    index: true
+  },
+  title: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  message: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  entityType: {
+    type: String,
+    enum: ['career', 'referral'],
+    default: null,
+    index: true
+  },
+  entityId: {
+    type: mongoose.Schema.Types.ObjectId,
+    default: null,
+    index: true
+  },
+  metadata: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {}
+  },
+  dedupeKey: {
+    type: String,
+    unique: true,
+    sparse: true,
+    index: true
+  },
+  isRead: {
+    type: Boolean,
+    default: false,
+    index: true
+  },
+  readAt: {
+    type: Date,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+notificationSchema.index({ user: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Notification', notificationSchema);

--- a/backend/models/NotificationPreference.model.js
+++ b/backend/models/NotificationPreference.model.js
@@ -1,0 +1,37 @@
+const mongoose = require('mongoose');
+
+const notificationPreferenceSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    unique: true,
+    index: true
+  },
+  enabled: {
+    type: Boolean,
+    default: false
+  },
+  deadlineApproaching: {
+    type: Boolean,
+    default: false
+  },
+  statusChanges: {
+    type: Boolean,
+    default: false
+  },
+  betterRecommendations: {
+    type: Boolean,
+    default: false
+  },
+  deadlineWindowDays: {
+    type: Number,
+    default: 3,
+    min: 1,
+    max: 30
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('NotificationPreference', notificationPreferenceSchema);

--- a/backend/models/ReferralModerationAction.model.js
+++ b/backend/models/ReferralModerationAction.model.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+
+const referralModerationActionSchema = new mongoose.Schema({
+  adminId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  referralId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'JobReferral',
+    required: true,
+    index: true
+  },
+  actionType: {
+    type: String,
+    enum: ['flag', 'hide', 'restore', 'suspend_poster'],
+    required: true,
+    index: true
+  },
+  reason: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  targetUserId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+referralModerationActionSchema.index({ referralId: 1, createdAt: -1 });
+
+module.exports = mongoose.model('ReferralModerationAction', referralModerationActionSchema);

--- a/backend/models/SavedItem.model.js
+++ b/backend/models/SavedItem.model.js
@@ -1,0 +1,56 @@
+const mongoose = require('mongoose');
+
+const savedItemSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  entityType: {
+    type: String,
+    enum: ['career', 'referral'],
+    required: true,
+    index: true
+  },
+  entityId: {
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+    index: true
+  },
+  entitySnapshot: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {}
+  },
+  savedScore: {
+    type: Number,
+    default: null
+  },
+  lastKnownStatus: {
+    type: String,
+    default: ''
+  },
+  lastKnownDeadlineAt: {
+    type: Date,
+    default: null
+  },
+  lastDeadlineReminderFor: {
+    type: Date,
+    default: null
+  },
+  lastRecommendationEntityId: {
+    type: mongoose.Schema.Types.ObjectId,
+    default: null
+  },
+  lastRecommendationScore: {
+    type: Number,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+savedItemSchema.index({ user: 1, entityType: 1, entityId: 1 }, { unique: true });
+savedItemSchema.index({ user: 1, createdAt: -1 });
+
+module.exports = mongoose.model('SavedItem', savedItemSchema);

--- a/backend/models/User.model.js
+++ b/backend/models/User.model.js
@@ -154,6 +154,24 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: ''
   },
+  referralPostingSuspended: {
+    type: Boolean,
+    default: false
+  },
+  referralPostingSuspendedAt: {
+    type: Date,
+    default: null
+  },
+  referralPostingSuspendedReason: {
+    type: String,
+    default: '',
+    trim: true
+  },
+  referralPostingSuspendedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null
+  },
   alumnus_bio: alumnusBioSchema,
   // added student bio schema
   student_bio: studentBioSchema

--- a/backend/routes/admin.routes.js
+++ b/backend/routes/admin.routes.js
@@ -14,6 +14,7 @@ const skillRouter=require('./skill.routes.js');
 const achievementRouter=require('./achievement.routes.js');
 const businessRouter=require('./business.routes.js');
 const badgeRouter=require('./badge.routes.js');
+const referralModerationRouter=require('./adminReferral.routes.js');
 
 const router=express.Router();
 
@@ -23,6 +24,7 @@ router.use('/dashboard', dashboardRouter);
 router.use('/users', userRouter);
 
 router.use('/jobs', careerRouter);
+router.use('/referrals', referralModerationRouter);
 router.use('/courses', courseRouter);
 router.use('/events', eventRouter);
 router.use('/forums', forumRouter);

--- a/backend/routes/adminReferral.routes.js
+++ b/backend/routes/adminReferral.routes.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const {
+  getAdminReferrals,
+  getReferralModerationActions,
+  flagReferralForSpam,
+  hideReferral,
+  restoreReferral,
+  suspendReferralPoster
+} = require('../controllers/referral.controller');
+const { authenticate, isAdmin } = require('../middlewares/auth.middleware');
+
+const router = express.Router();
+
+router.use(authenticate, isAdmin);
+
+router.get('/', getAdminReferrals);
+router.get('/:id/moderation-actions', getReferralModerationActions);
+router.post('/:id/flag', flagReferralForSpam);
+router.post('/:id/hide', hideReferral);
+router.post('/:id/restore', restoreReferral);
+router.post('/:id/suspend-poster', suspendReferralPoster);
+
+module.exports = router;

--- a/backend/routes/notification.routes.js
+++ b/backend/routes/notification.routes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { authenticate } = require('../middlewares/auth.middleware');
+const {
+  getNotifications,
+  markNotificationRead,
+  getNotificationPreferences,
+  updateNotificationPreferences
+} = require('../controllers/opportunity.controller');
+
+const router = express.Router();
+
+router.get('/', authenticate, getNotifications);
+router.patch('/:id/read', authenticate, markNotificationRead);
+router.get('/preferences', authenticate, getNotificationPreferences);
+router.patch('/preferences', authenticate, updateNotificationPreferences);
+
+module.exports = router;

--- a/backend/routes/referral.routes.js
+++ b/backend/routes/referral.routes.js
@@ -16,6 +16,18 @@ const { authenticate, isStudent } = require('../middlewares/auth.middleware');
 
 const router = express.Router();
 
+const allowBonusCompute = (req, res, next) => {
+  const internalToken = process.env.INTERNAL_BONUS_TOKEN;
+  const providedToken = req.headers['x-internal-bonus-token'];
+  const isInternal = Boolean(internalToken && providedToken && providedToken === internalToken);
+
+  if (isInternal || req.user?.type === 'admin') {
+    return next();
+  }
+
+  return res.status(403).json({ message: 'Admin access required' });
+};
+
 // Create new referral opportunity (alumni)
 router.post('/', authenticate, createReferral);
 
@@ -28,6 +40,9 @@ router.post('/:id/apply', authenticate, isStudent, applyForReferral);
 // Referral Q&A / messaging
 router.post('/:id/messages', authenticate, sendReferralMessage);
 router.get('/:id/messages', authenticate, getReferralMessages);
+
+// Referral bonus computation
+router.post('/:id/compute-bonus', authenticate, allowBonusCompute, computeReferralBonus);
 
 // Manage applicants (only poster)
 router.put('/:id/applicants/:applicantId/accept', authenticate, acceptReferral);

--- a/backend/routes/saved.routes.js
+++ b/backend/routes/saved.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { authenticate } = require('../middlewares/auth.middleware');
+const {
+  getSavedItems,
+  toggleSavedItem
+} = require('../controllers/opportunity.controller');
+
+const router = express.Router();
+
+router.get('/', authenticate, getSavedItems);
+router.post('/', authenticate, toggleSavedItem);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,10 +26,13 @@ const courseRouter = require('./routes/course.routes');
 const eventCalendarRouter = require('./routes/eventCalendar.routes');
 const reunionRouter = require('./routes/reunion.routes');
 const referralRouter = require('./routes/referral.routes');
+const savedRouter = require('./routes/saved.routes');
+const notificationRouter = require('./routes/notification.routes');
 const streamRouter = require('./routes/stream.routes');
 const resumeAnalyzerRouter = require('./routes/resumeAnalyzer.routes');
 const marketplaceRouter = require('./routes/marketplace.routes');
 const pollRouter = require('./routes/poll.routes');
+const { startOpportunityNotificationScanner } = require('./services/opportunityNotificationService');
 
 dotenv.config();
 const app = express();
@@ -138,6 +141,8 @@ app.use('/api/v1/courses', courseRouter);
 app.use('/api/v1/event-calendar', eventCalendarRouter);
 app.use('/api/v1/reunions', reunionRouter);
 app.use('/api/v1/referrals', referralRouter);
+app.use('/api/v1/saved', savedRouter);
+app.use('/api/v1/notifications', notificationRouter);
 app.use('/api/v1/stream', streamRouter);
 app.use('/api/v1/resume-analyzer', resumeAnalyzerRouter);
 app.use('/api/v1/marketplace', marketplaceRouter);
@@ -156,6 +161,8 @@ app.use('/api/courses', courseRouter);
 app.use('/api/event-calendar', eventCalendarRouter);
 app.use('/api/reunions', reunionRouter);
 app.use('/api/referrals', referralRouter);
+app.use('/api/saved', savedRouter);
+app.use('/api/notifications', notificationRouter);
 app.use('/api/marketplace', marketplaceRouter);
 app.use('/api/polls', pollRouter);
 app.use('/api', badgeRouter);
@@ -202,6 +209,8 @@ const io = socketIO(server, {
 });
 
 app.set('io', io);
+
+startOpportunityNotificationScanner();
 
 // Initialize socket event handlers
 initializeSocket(io);

--- a/backend/services/opportunityNotificationService.js
+++ b/backend/services/opportunityNotificationService.js
@@ -1,0 +1,352 @@
+const { Career, JobReferral, User, JobPreference, JobSubscription, SavedItem, Notification, NotificationPreference } = require('../models/Index');
+const logger = require('../utils/logger');
+
+let scanTimer = null;
+
+function normalizeEntityType(entityType = '') {
+  const normalized = String(entityType).trim().toLowerCase();
+
+  if (['career', 'job', 'jobs'].includes(normalized)) {
+    return 'career';
+  }
+
+  if (['referral', 'referrals'].includes(normalized)) {
+    return 'referral';
+  }
+
+  return null;
+}
+
+function normalizeStatus(status, fallback = '') {
+  return String(status || fallback || '').trim().toLowerCase();
+}
+
+function calculateCareerMatchScore(preferences = {}, career = {}) {
+  const userSkills = preferences?.preferredSkills || [];
+  const preferredJobTypes = preferences?.preferredJobTypes || [];
+  const preferredLocations = preferences?.preferredLocations || [];
+  const preferredExperienceLevels = preferences?.preferredExperienceLevels || [];
+
+  let skillsScore = 0;
+  const matchedSkills = [];
+
+  if (userSkills.length > 0 && career.skills && career.skills.length > 0) {
+    const normalizedUserSkills = userSkills.map((skill) => skill.toLowerCase().trim());
+    const normalizedCareerSkills = career.skills.map((skill) => skill.toLowerCase().trim());
+
+    normalizedCareerSkills.forEach((careerSkill) => {
+      if (normalizedUserSkills.some((userSkill) => userSkill.includes(careerSkill) || careerSkill.includes(userSkill))) {
+        matchedSkills.push(careerSkill);
+      }
+    });
+
+    const matchedCount = matchedSkills.length;
+    skillsScore = normalizedCareerSkills.length > 0
+      ? Math.round((matchedCount / normalizedCareerSkills.length) * 100)
+      : 0;
+  }
+
+  let jobTypeScore = 0;
+  if (preferredJobTypes.length > 0 && career.job_type) {
+    jobTypeScore = preferredJobTypes.includes(career.job_type) ? 100 : 0;
+  }
+
+  let locationScore = 0;
+  if (preferredLocations.length > 0 && career.location) {
+    const careerLocation = career.location.toLowerCase();
+    const locationMatch = preferredLocations.some((preferredLocation) => (
+      careerLocation.includes(preferredLocation.toLowerCase()) || preferredLocation.toLowerCase().includes(careerLocation)
+    ));
+    locationScore = locationMatch ? 100 : 0;
+  }
+
+  let experienceScore = 0;
+  if (preferredExperienceLevels.length > 0 && career.experience_level) {
+    experienceScore = preferredExperienceLevels.includes(career.experience_level) ? 100 : 0;
+  }
+
+  const totalScore = Math.round(
+    (skillsScore * 0.5)
+    + (jobTypeScore * 0.2)
+    + (locationScore * 0.2)
+    + (experienceScore * 0.1)
+  );
+
+  return {
+    totalScore,
+    skillsScore,
+    jobTypeScore,
+    locationScore,
+    experienceScore,
+    matchedSkills
+  };
+}
+
+async function resolveUserPreferences(userId) {
+  const user = await User.findById(userId);
+  const userSkills = user?.alumnus_bio?.skills || [];
+
+  let preferences = await JobPreference.findOne({ user: userId });
+  if (preferences) {
+    return {
+      user,
+      userSkills,
+      preferences: preferences.toObject ? preferences.toObject() : preferences
+    };
+  }
+
+  const subscription = await JobSubscription.findOne({ user: userId, isActive: true });
+  if (subscription) {
+    return {
+      user,
+      userSkills,
+      preferences: {
+        preferredSkills: subscription.preferredSkills || userSkills,
+        preferredJobTypes: subscription.preferredJobTypes || ['full-time', 'part-time'],
+        preferredLocations: subscription.preferredLocations || [],
+        preferredExperienceLevels: subscription.preferredExperienceLevels || ['entry', 'mid', 'senior']
+      }
+    };
+  }
+
+  return {
+    user,
+    userSkills,
+    preferences: {
+      preferredSkills: userSkills,
+      preferredJobTypes: ['full-time', 'part-time'],
+      preferredLocations: [],
+      preferredExperienceLevels: ['entry', 'mid', 'senior']
+    }
+  };
+}
+
+async function buildSavedItemSnapshot(entityType, entity, preferences = {}) {
+  if (entityType === 'career') {
+    const matchScore = calculateCareerMatchScore(preferences, entity).totalScore;
+
+    return {
+      title: entity.job_title,
+      company: entity.company,
+      location: entity.location,
+      status: normalizeStatus(entity.status, 'open'),
+      deadline: entity.deadline || null,
+      matchScore,
+      jobType: entity.job_type || '',
+      description: entity.description || ''
+    };
+  }
+
+  return {
+    title: entity.jobTitle,
+    company: entity.company,
+    location: '',
+    status: normalizeStatus(entity.status, 'open'),
+    deadline: entity.deadline || null,
+    matchScore: null,
+    description: entity.description || ''
+  };
+}
+
+function isDeadlineApproaching(deadline, windowDays = 3) {
+  if (!deadline) {
+    return false;
+  }
+
+  const targetDate = new Date(deadline);
+  if (Number.isNaN(targetDate.getTime())) {
+    return false;
+  }
+
+  const now = new Date();
+  if (targetDate <= now) {
+    return false;
+  }
+
+  const windowMs = Math.max(1, Number(windowDays) || 3) * 24 * 60 * 60 * 1000;
+  return (targetDate.getTime() - now.getTime()) <= windowMs;
+}
+
+async function createNotificationIfMissing(payload) {
+  const existing = await Notification.findOne({ dedupeKey: payload.dedupeKey });
+  if (existing) {
+    return existing;
+  }
+
+  return Notification.create(payload);
+}
+
+async function scanOpportunityNotifications() {
+  const preferencesList = await NotificationPreference.find({ enabled: true });
+  let createdCount = 0;
+
+  for (const preference of preferencesList) {
+    const savedItems = await SavedItem.find({ user: preference.user });
+    if (!savedItems.length) {
+      continue;
+    }
+
+    const { preferences } = await resolveUserPreferences(preference.user);
+
+    let topRecommendation = null;
+    if (preference.betterRecommendations) {
+      const openCareers = await Career.find({ status: 'open' }).sort({ createdAt: -1 }).limit(150);
+      const scoredCareers = openCareers
+        .map((career) => ({
+          career,
+          score: calculateCareerMatchScore(preferences, career).totalScore
+        }))
+        .sort((left, right) => right.score - left.score);
+
+      topRecommendation = scoredCareers[0] || null;
+    }
+
+    for (const savedItem of savedItems) {
+      const entity = savedItem.entityType === 'career'
+        ? await Career.findById(savedItem.entityId)
+        : await JobReferral.findById(savedItem.entityId);
+
+      if (!entity) {
+        continue;
+      }
+
+      const currentStatus = normalizeStatus(entity.status, savedItem.lastKnownStatus || 'open');
+      const currentDeadline = entity.deadline ? new Date(entity.deadline) : null;
+
+      if (preference.statusChanges && savedItem.lastKnownStatus && currentStatus !== savedItem.lastKnownStatus) {
+        const dedupeKey = `status:${preference.user}:${savedItem._id}:${currentStatus}`;
+        const notification = await createNotificationIfMissing({
+          user: preference.user,
+          type: 'status-change',
+          title: 'Saved opportunity status changed',
+          message: `${entity.job_title || entity.jobTitle || 'A saved opportunity'} changed from ${savedItem.lastKnownStatus} to ${currentStatus}.`,
+          entityType: savedItem.entityType,
+          entityId: savedItem.entityId,
+          metadata: {
+            previousStatus: savedItem.lastKnownStatus,
+            currentStatus
+          },
+          dedupeKey
+        });
+
+        if (notification) {
+          createdCount += 1;
+        }
+
+        savedItem.lastKnownStatus = currentStatus;
+      }
+
+      if (
+        preference.deadlineApproaching
+        && currentDeadline
+        && isDeadlineApproaching(currentDeadline, preference.deadlineWindowDays)
+      ) {
+        const lastNotifiedFor = savedItem.lastDeadlineReminderFor ? new Date(savedItem.lastDeadlineReminderFor) : null;
+        const alreadyNotified = lastNotifiedFor && !Number.isNaN(lastNotifiedFor.getTime())
+          && lastNotifiedFor.getTime() === currentDeadline.getTime();
+
+        if (!alreadyNotified) {
+          const dedupeKey = `deadline:${preference.user}:${savedItem._id}:${currentDeadline.toISOString()}`;
+          const notification = await createNotificationIfMissing({
+            user: preference.user,
+            type: 'deadline',
+            title: 'Deadline approaching',
+            message: `${entity.job_title || entity.jobTitle || 'A saved opportunity'} at ${entity.company || 'Unknown company'} closes on ${currentDeadline.toLocaleDateString()}.`,
+            entityType: savedItem.entityType,
+            entityId: savedItem.entityId,
+            metadata: {
+              deadline: currentDeadline,
+              windowDays: preference.deadlineWindowDays
+            },
+            dedupeKey
+          });
+
+          if (notification) {
+            createdCount += 1;
+          }
+
+          savedItem.lastDeadlineReminderFor = currentDeadline;
+        }
+      }
+
+      if (preference.betterRecommendations && savedItem.entityType === 'career' && topRecommendation?.career) {
+        const savedScore = Number(savedItem.savedScore || savedItem.entitySnapshot?.matchScore || 0);
+        const topScore = Number(topRecommendation.score || 0);
+        const topCareerId = topRecommendation.career._id.toString();
+
+        if (topScore > savedScore + 10 && topCareerId !== savedItem.entityId.toString()) {
+          const dedupeKey = `recommendation:${preference.user}:${savedItem._id}:${topCareerId}:${topScore}`;
+          const notification = await createNotificationIfMissing({
+            user: preference.user,
+            type: 'better-recommendation',
+            title: 'A better match appeared',
+            message: `${topRecommendation.career.job_title} at ${topRecommendation.career.company} is a ${topScore}% match, which is stronger than your saved job.`,
+            entityType: 'career',
+            entityId: topRecommendation.career._id,
+            metadata: {
+              savedItemId: savedItem._id,
+              savedScore,
+              topScore
+            },
+            dedupeKey
+          });
+
+          if (notification) {
+            createdCount += 1;
+          }
+
+          savedItem.lastRecommendationEntityId = topRecommendation.career._id;
+          savedItem.lastRecommendationScore = topScore;
+        }
+      }
+
+      if (savedItem.isModified()) {
+        await savedItem.save();
+      }
+    }
+  }
+
+  return {
+    usersScanned: preferencesList.length,
+    createdCount
+  };
+}
+
+function startOpportunityNotificationScanner() {
+  if (scanTimer) {
+    return scanTimer;
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    return null;
+  }
+
+  const intervalMs = Number(process.env.OPPORTUNITY_NOTIFICATION_SCAN_MS || 5 * 60 * 1000);
+
+  const runScan = () => {
+    scanOpportunityNotifications().catch((error) => {
+      logger.logError(error, {
+        operation: 'scan-opportunity-notifications'
+      });
+    });
+  };
+
+  runScan();
+  scanTimer = setInterval(runScan, intervalMs);
+
+  if (typeof scanTimer.unref === 'function') {
+    scanTimer.unref();
+  }
+
+  return scanTimer;
+}
+
+module.exports = {
+  normalizeEntityType,
+  normalizeStatus,
+  calculateCareerMatchScore,
+  resolveUserPreferences,
+  buildSavedItemSnapshot,
+  scanOpportunityNotifications,
+  startOpportunityNotificationScanner
+};

--- a/backend/services/referralBonusService.js
+++ b/backend/services/referralBonusService.js
@@ -1,0 +1,183 @@
+const { JobReferral } = require('../models/Index');
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function getDeadlinePenaltyPercent(deadlineReductionPerDayPercent = 0, deadlineReductionCapPercent = 100, referenceDate, deadline) {
+  if (!deadline || !referenceDate) {
+    return 0;
+  }
+
+  const deadlineTime = new Date(deadline).getTime();
+  const referenceTime = new Date(referenceDate).getTime();
+
+  if (Number.isNaN(deadlineTime) || Number.isNaN(referenceTime) || referenceTime <= deadlineTime) {
+    return 0;
+  }
+
+  const lateDays = Math.max(1, Math.ceil((referenceTime - deadlineTime) / (24 * 60 * 60 * 1000)));
+  return Math.min(
+    toNumber(deadlineReductionCapPercent, 100),
+    lateDays * toNumber(deadlineReductionPerDayPercent, 0)
+  );
+}
+
+function buildPolicySnapshot(referral) {
+  return {
+    payoutOn: referral.bonusPolicy?.payoutOn || 'filled',
+    companyName: referral.bonusPolicy?.companyName || referral.company || '',
+    companyMultiplier: toNumber(referral.bonusPolicy?.companyMultiplier, 1),
+    companyFlatBonus: toNumber(referral.bonusPolicy?.companyFlatBonus, 0),
+    deadlineReductionPerDayPercent: toNumber(referral.bonusPolicy?.deadlineReductionPerDayPercent, 0),
+    deadlineReductionCapPercent: toNumber(referral.bonusPolicy?.deadlineReductionCapPercent, 100),
+    enabled: referral.bonusPolicy?.enabled !== false,
+    notes: referral.bonusPolicy?.notes || ''
+  };
+}
+
+function normalizeApplicant(applicant) {
+  if (!applicant) {
+    return {
+      applicantId: null,
+      applicantName: ''
+    };
+  }
+
+  const applicantUser = applicant.user;
+  return {
+    applicantId: applicantUser?._id || applicantUser || null,
+    applicantName: applicantUser?.name || applicant.applicantName || applicant.name || ''
+  };
+}
+
+async function resolveEligibleApplicant(referral, payoutEvent) {
+  if (!referral?.applicants?.length) {
+    return null;
+  }
+
+  if (payoutEvent === 'accepted') {
+    const acceptedApplicant = referral.applicants.find((applicant) => applicant.status === 'accepted');
+    return acceptedApplicant || null;
+  }
+
+  const acceptedApplicant = referral.applicants.find((applicant) => applicant.status === 'accepted');
+  return acceptedApplicant || null;
+}
+
+async function computeReferralBonus(referralInput, options = {}) {
+  const referral = referralInput?.populate ? referralInput : await JobReferral.findById(referralInput?._id || referralInput);
+
+  if (!referral) {
+    throw new Error('Referral not found');
+  }
+
+  const policy = buildPolicySnapshot(referral);
+  const payoutEvent = policy.payoutOn || 'filled';
+  const baseAmount = toNumber(referral.referralBonus, 0);
+
+  const currentStatus = String(referral.status || 'open').toLowerCase();
+  const payoutAchieved = payoutEvent === 'accepted'
+    ? referral.applicants?.some((applicant) => applicant.status === 'accepted')
+    : currentStatus === 'filled';
+
+  const eligibleApplicant = await resolveEligibleApplicant(referral, payoutEvent);
+  const eligibleApplicantStartAt = eligibleApplicant?.acceptedAt || (payoutEvent === 'filled' ? referral.filledAt : null);
+  const normalizedApplicant = normalizeApplicant(eligibleApplicant);
+
+  const response = {
+    status: 'pending',
+    amount: 0,
+    baseAmount,
+    multiplier: policy.companyMultiplier,
+    flatBonus: policy.companyFlatBonus,
+    deadlinePenaltyPercent: 0,
+    deadlinePenaltyAmount: 0,
+    payoutEvent,
+    eligibleApplicantId: normalizedApplicant.applicantId,
+    eligibleApplicantName: normalizedApplicant.applicantName,
+    computedAt: new Date(),
+    computedBy: options.computedBy || null,
+    reason: '',
+    policySnapshot: policy
+  };
+
+  if (!policy.enabled) {
+    response.status = 'not-eligible';
+    response.reason = 'Referral bonus policy is disabled';
+    return response;
+  }
+
+  if (!payoutAchieved) {
+    response.status = 'pending';
+    response.reason = payoutEvent === 'accepted'
+      ? 'Bonus becomes eligible when an applicant is accepted'
+      : 'Bonus becomes eligible when the referral is filled';
+    return response;
+  }
+
+  if (!eligibleApplicant) {
+    response.status = 'not-eligible';
+    response.reason = 'No accepted applicant was found';
+    return response;
+  }
+
+  const deadlinePenaltyPercent = getDeadlinePenaltyPercent(
+    policy.deadlineReductionPerDayPercent,
+    policy.deadlineReductionCapPercent,
+    eligibleApplicantStartAt,
+    referral.deadline
+  );
+
+  const prePenaltyAmount = Math.max(
+    0,
+    Math.round((baseAmount * policy.companyMultiplier) + policy.companyFlatBonus)
+  );
+  const deadlinePenaltyAmount = Math.round(prePenaltyAmount * (deadlinePenaltyPercent / 100));
+  const finalAmount = Math.max(0, prePenaltyAmount - deadlinePenaltyAmount);
+
+  response.status = finalAmount > 0 ? 'eligible' : 'not-eligible';
+  response.amount = finalAmount;
+  response.deadlinePenaltyPercent = deadlinePenaltyPercent;
+  response.deadlinePenaltyAmount = deadlinePenaltyAmount;
+  response.reason = finalAmount > 0
+    ? (deadlinePenaltyPercent > 0 ? 'Bonus reduced because the applicant started after the deadline' : 'Bonus eligible')
+    : 'Bonus amount resolved to zero';
+  response.eligibleApplicantId = normalizedApplicant.applicantId;
+  response.eligibleApplicantName = normalizedApplicant.applicantName;
+
+  return response;
+}
+
+async function persistReferralBonus(referral, computedBonus) {
+  referral.bonusComputation = {
+    ...referral.bonusComputation?.toObject?.() || referral.bonusComputation || {},
+    ...computedBonus
+  };
+
+  await referral.save();
+  return referral;
+}
+
+async function recomputeAndPersistReferralBonus(referral, options = {}) {
+  const computedBonus = await computeReferralBonus(referral, options);
+  const persistedReferral = await JobReferral.findById(referral._id);
+
+  if (!persistedReferral) {
+    throw new Error('Referral not found');
+  }
+
+  persistedReferral.bonusComputation = computedBonus;
+  await persistedReferral.save();
+
+  return {
+    referral: persistedReferral,
+    bonus: computedBonus
+  };
+}
+
+module.exports = {
+  computeReferralBonus,
+  recomputeAndPersistReferralBonus
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,6 +50,7 @@ import RegisterBusiness from "./components/RegisterBusiness";
 import MyBusiness from "./components/MyBusiness";
 import ReferralList from "./components/ReferralList";
 import ReferralDetail from "./components/ReferralDetail";
+import NotificationsPage from "./components/NotificationsPage";
 import Marketplace from "./components/Marketplace";
 import MarketplaceForm from "./components/MarketplaceForm";
 import MarketplaceDetail from "./components/MarketplaceDetail";
@@ -68,6 +69,7 @@ const privateComponentMap = {
   MyBusiness,
   ReferralList,
   ReferralDetail,
+  NotificationsPage,
 };
 
 function App() {
@@ -159,22 +161,6 @@ function AppRouter() {
         </Route>
 
         {/* Private Routes - imported from centralized config */}
-        {privateRoutes.map((route, index) => {
-          const Component = privateComponentMap[route.component];
-          return (
-            <Route
-              key={index}
-              path={route.path}
-              element={
-                <PrivateRoute allow={route.roles}>
-                  <Component />
-                </PrivateRoute>
-              }
-            />
-          );
-        })}
-
-        {/* Referral Routes */}
         {privateRoutes.map((route, index) => {
           const Component = privateComponentMap[route.component];
           return (

--- a/frontend/src/admin/AdminReferrals.jsx
+++ b/frontend/src/admin/AdminReferrals.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import apiClient from '../api/client';
-import { useAuth } from '../AuthContext';
 
 const statusColors = {
     pending: 'warning',
@@ -13,28 +12,87 @@ const statusColors = {
     withdrawn: 'secondary'
 };
 
+const moderationStatusColors = {
+    visible: 'success',
+    flagged: 'warning',
+    hidden: 'danger',
+    removed: 'dark'
+};
+
+const moderationActionLabels = {
+    flag: 'Flag spam',
+    hide: 'Hide content',
+    restore: 'Restore content',
+    suspend_poster: 'Suspend poster'
+};
+
 const AdminReferrals = () => {
-    const { user } = useAuth();
-    const [referrals, setReferrals] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState('');
-    const [selectedReferral, setSelectedReferral] = useState(null);
+    const [jobReferrals, setJobReferrals] = useState([]);
+    const [jobLoading, setJobLoading] = useState(true);
+    const [jobError, setJobError] = useState('');
     const [statusFilter, setStatusFilter] = useState('all');
+    const [moderationReferrals, setModerationReferrals] = useState([]);
+    const [moderationLoading, setModerationLoading] = useState(true);
+    const [moderationError, setModerationError] = useState('');
+    const [moderationFilter, setModerationFilter] = useState('all');
+    const [selectedModerationReferralId, setSelectedModerationReferralId] = useState('');
+    const [moderationActions, setModerationActions] = useState([]);
+    const [auditLoading, setAuditLoading] = useState(false);
 
     useEffect(() => {
-        fetchReferrals();
+        fetchJobReferrals();
+        fetchModerationReferrals();
     }, []);
 
-    const fetchReferrals = async () => {
+    const fetchJobReferrals = async () => {
         try {
-            setLoading(true);
+            setJobLoading(true);
             const res = await apiClient.get('/admin/jobs/all-referrals');
-            setReferrals(res.data);
+            setJobReferrals(res.data);
         } catch (err) {
-            setError('Failed to load referrals');
+            setJobError('Failed to load job referrals');
             console.error(err);
         } finally {
-            setLoading(false);
+            setJobLoading(false);
+        }
+    };
+
+    const fetchModerationReferrals = async () => {
+        try {
+            setModerationLoading(true);
+            const res = await apiClient.get('/admin/referrals');
+            const referrals = res.data?.referrals || [];
+            setModerationReferrals(referrals);
+
+            if (!selectedModerationReferralId && referrals.length > 0) {
+                setSelectedModerationReferralId(referrals[0]._id);
+                fetchModerationActions(referrals[0]._id);
+            }
+        } catch (err) {
+            setModerationError('Failed to load referral moderation data');
+            console.error(err);
+        } finally {
+            setModerationLoading(false);
+        }
+    };
+
+    const fetchModerationActions = async (referralId) => {
+        if (!referralId) {
+            setModerationActions([]);
+            return;
+        }
+
+        try {
+            setAuditLoading(true);
+            const res = await apiClient.get(`/admin/referrals/${referralId}/moderation-actions`);
+            setModerationActions(res.data?.actions || []);
+            setSelectedModerationReferralId(referralId);
+        } catch (err) {
+            console.error(err);
+            setModerationActions([]);
+            alert('Failed to load moderation audit log');
+        } finally {
+            setAuditLoading(false);
         }
     };
 
@@ -44,30 +102,61 @@ const AdminReferrals = () => {
                 `/admin/jobs/referrals/${referralId}/status`,
                 { status: newStatus }
             );
-            fetchReferrals();
+            fetchJobReferrals();
         } catch (err) {
             alert('Failed to update status');
         }
     };
 
-    const filteredReferrals = statusFilter === 'all' 
-        ? referrals 
-        : referrals.filter(r => r.status === statusFilter);
+    const handleModerationAction = async (referralId, actionType, defaultReason) => {
+        const reason = window.prompt(`Reason for ${moderationActionLabels[actionType] || actionType}`, defaultReason || '');
 
-    if (loading) {
-        return <div className="text-center mt-5">Loading referrals...</div>;
-    }
+        if (reason === null) {
+            return;
+        }
 
-    return (
-        <div className="container-fluid">
-            <div className="d-flex justify-content-between align-items-center mb-4">
-                <h2>Job Referrals Management</h2>
-                <div>
+        try {
+            await apiClient.post(`/admin/referrals/${referralId}/${actionType}`, {
+                reason: reason.trim() || defaultReason || ''
+            });
+
+            await Promise.all([
+                fetchModerationReferrals(),
+                fetchJobReferrals()
+            ]);
+
+            fetchModerationActions(referralId);
+        } catch (err) {
+            alert(err.response?.data?.message || 'Failed to update moderation state');
+        }
+    };
+
+    const filteredJobReferrals = statusFilter === 'all'
+        ? jobReferrals
+        : jobReferrals.filter(r => r.status === statusFilter);
+
+    const filteredModerationReferrals = moderationFilter === 'all'
+        ? moderationReferrals
+        : moderationReferrals.filter((referral) => (referral.moderation?.status || 'visible') === moderationFilter);
+
+    const selectedModerationReferral = moderationReferrals.find(
+        (referral) => referral._id === selectedModerationReferralId
+    ) || null;
+
+    const renderJobSection = () => {
+        if (jobLoading) {
+            return <div className="text-center mt-4">Loading job referrals...</div>;
+        }
+
+        return (
+            <div className="card">
+                <div className="card-header d-flex flex-wrap justify-content-between align-items-center gap-3">
+                    <h5 className="mb-0">Job Referrals Management</h5>
                     <select 
                         className="form-select" 
                         value={statusFilter}
                         onChange={(e) => setStatusFilter(e.target.value)}
-                        style={{ width: '200px' }}
+                        style={{ width: '220px' }}
                     >
                         <option value="all">All Status</option>
                         <option value="pending">Pending</option>
@@ -80,15 +169,6 @@ const AdminReferrals = () => {
                         <option value="withdrawn">Withdrawn</option>
                     </select>
                 </div>
-            </div>
-
-            {error && (
-                <div className="alert alert-danger" role="alert">
-                    {error}
-                </div>
-            )}
-
-            <div className="card">
                 <div className="card-body">
                     <div className="table-responsive">
                         <table className="table table-hover">
@@ -103,12 +183,19 @@ const AdminReferrals = () => {
                                 </tr>
                             </thead>
                             <tbody>
-                                {filteredReferrals.length === 0 ? (
+                                {jobError && (
+                                    <tr>
+                                        <td colSpan="6">
+                                            <div className="alert alert-danger mb-0">{jobError}</div>
+                                        </td>
+                                    </tr>
+                                )}
+                                {!jobError && filteredJobReferrals.length === 0 ? (
                                     <tr>
                                         <td colSpan="6" className="text-center">No referrals found</td>
                                     </tr>
                                 ) : (
-                                    filteredReferrals.map((referral) => (
+                                    filteredJobReferrals.map((referral) => (
                                         <tr key={referral._id}>
                                             <td>
                                                 <strong>{referral.candidateName}</strong><br />
@@ -175,6 +262,173 @@ const AdminReferrals = () => {
                     </div>
                 </div>
             </div>
+        );
+    };
+
+    const renderModerationSection = () => {
+        return (
+            <div className="card mt-4">
+                <div className="card-header d-flex flex-wrap justify-content-between align-items-center gap-3">
+                    <div>
+                        <h5 className="mb-1">Referral Moderation & Audit Trail</h5>
+                        <small className="text-muted">Flag spam, hide content, restore posts, and suspend the poster from referral publishing.</small>
+                    </div>
+                    <select
+                        className="form-select"
+                        value={moderationFilter}
+                        onChange={(e) => setModerationFilter(e.target.value)}
+                        style={{ width: '220px' }}
+                    >
+                        <option value="all">All moderation states</option>
+                        <option value="visible">Visible</option>
+                        <option value="flagged">Flagged</option>
+                        <option value="hidden">Hidden</option>
+                        <option value="removed">Removed</option>
+                    </select>
+                </div>
+
+                <div className="card-body">
+                    {moderationError && (
+                        <div className="alert alert-danger" role="alert">
+                            {moderationError}
+                        </div>
+                    )}
+
+                    {moderationLoading ? (
+                        <div className="text-center py-4">Loading moderation queue...</div>
+                    ) : (
+                        <div className="row g-4">
+                            <div className="col-12 col-xl-7">
+                                <div className="table-responsive">
+                                    <table className="table table-hover align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Referral</th>
+                                                <th>Poster</th>
+                                                <th>State</th>
+                                                <th>Actions</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {filteredModerationReferrals.length === 0 ? (
+                                                <tr>
+                                                    <td colSpan="4" className="text-center">No referrals found</td>
+                                                </tr>
+                                            ) : (
+                                                filteredModerationReferrals.map((referral) => {
+                                                    const moderationStatus = referral.moderation?.status || 'visible';
+                                                    const isSelected = selectedModerationReferralId === referral._id;
+
+                                                    return (
+                                                        <tr key={referral._id} className={isSelected ? 'table-primary' : ''}>
+                                                            <td>
+                                                                <strong>{referral.jobTitle}</strong><br />
+                                                                <small className="text-muted">{referral.company}</small><br />
+                                                                <small className="text-muted">Created {new Date(referral.createdAt).toLocaleDateString()}</small>
+                                                            </td>
+                                                            <td>
+                                                                <strong>{referral.postedBy?.name || 'Unknown'}</strong><br />
+                                                                <small className="text-muted">{referral.postedBy?.email}</small><br />
+                                                                {referral.postedBy?.referralPostingSuspended && (
+                                                                    <span className="badge bg-danger mt-1">Poster suspended</span>
+                                                                )}
+                                                            </td>
+                                                            <td>
+                                                                <span className={`badge bg-${moderationStatusColors[moderationStatus] || 'secondary'}`}>
+                                                                    {moderationStatus}
+                                                                </span>
+                                                                {referral.moderation?.reason && (
+                                                                    <div className="small text-muted mt-1">{referral.moderation.reason}</div>
+                                                                )}
+                                                            </td>
+                                                            <td>
+                                                                <div className="d-flex flex-wrap gap-2">
+                                                                    <button className="btn btn-sm btn-outline-warning" onClick={() => handleModerationAction(referral._id, 'flag', 'Spam review')}>
+                                                                        Flag
+                                                                    </button>
+                                                                    <button className="btn btn-sm btn-outline-danger" onClick={() => handleModerationAction(referral._id, 'hide', 'Hidden after moderation review')}>
+                                                                        Hide
+                                                                    </button>
+                                                                    <button className="btn btn-sm btn-outline-success" onClick={() => handleModerationAction(referral._id, 'restore', 'Restored after review')}>
+                                                                        Restore
+                                                                    </button>
+                                                                    <button className="btn btn-sm btn-outline-dark" onClick={() => handleModerationAction(referral._id, 'suspend-poster', 'Poster suspended for abusive referral content')}>
+                                                                        Suspend poster
+                                                                    </button>
+                                                                    <button className="btn btn-sm btn-outline-secondary" onClick={() => fetchModerationActions(referral._id)}>
+                                                                        Audit log
+                                                                    </button>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    );
+                                                })
+                                            )}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+
+                            <div className="col-12 col-xl-5">
+                                <div className="card border-0 bg-light h-100">
+                                    <div className="card-body">
+                                        <div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+                                            <div>
+                                                <h6 className="mb-1">Audit trail</h6>
+                                                <small className="text-muted">
+                                                    {selectedModerationReferral ? `${selectedModerationReferral.jobTitle} at ${selectedModerationReferral.company}` : 'Select a referral to review history'}
+                                                </small>
+                                            </div>
+                                            {selectedModerationReferral && (
+                                                <button className="btn btn-sm btn-outline-secondary" onClick={() => fetchModerationActions(selectedModerationReferral._id)}>
+                                                    Refresh
+                                                </button>
+                                            )}
+                                        </div>
+
+                                        {auditLoading ? (
+                                            <div className="text-center py-4">Loading audit trail...</div>
+                                        ) : moderationActions.length === 0 ? (
+                                            <div className="text-muted">No moderation actions recorded yet.</div>
+                                        ) : (
+                                            <div className="list-group list-group-flush">
+                                                {moderationActions.map((action) => (
+                                                    <div key={action._id} className="list-group-item bg-transparent px-0">
+                                                        <div className="d-flex justify-content-between align-items-start gap-3">
+                                                            <div>
+                                                                <div className="fw-semibold">{moderationActionLabels[action.actionType] || action.actionType}</div>
+                                                                <div className="small text-muted">
+                                                                    by {action.adminId?.name || 'Admin'}
+                                                                    {action.adminId?.email ? ` (${action.adminId.email})` : ''}
+                                                                </div>
+                                                                {action.reason && <div className="small mt-1">{action.reason}</div>}
+                                                            </div>
+                                                            <div className="text-end small text-muted">
+                                                                {new Date(action.createdAt).toLocaleString()}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div className="container-fluid">
+            <div className="d-flex justify-content-between align-items-center mb-4">
+                <h2>Job Referrals Management</h2>
+            </div>
+
+            {renderJobSection()}
+            {renderModerationSection()}
         </div>
     );
 };

--- a/frontend/src/components/Careers.jsx
+++ b/frontend/src/components/Careers.jsx
@@ -1,9 +1,11 @@
 import axios from 'axios';
 import React, { useEffect, useMemo, useState } from 'react'
-import { FaBuilding, FaMapMarker, FaPlus, FaSearch, FaStar, FaThumbsUp, FaUserPlus } from 'react-icons/fa';
+import { FaBookmark, FaBuilding, FaMapMarker, FaPlus, FaRegBookmark, FaSearch, FaStar, FaThumbsUp, FaUserPlus } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import ViewJobs from '../admin/view/ViewJobs';
 import ManageJobs from '../admin/save/ManageJobs';
+import apiClient from '../api/client';
 import { useAuth } from '../AuthContext';
 import { baseUrl } from '../utils/globalurl';
 import { smoothScrollToTop } from '../utils/smoothScroll';
@@ -56,6 +58,7 @@ const Careers = () => {
     const [recommendations, setRecommendations] = useState([]);
     const [loadingRecommendations, setLoadingRecommendations] = useState(false);
     const [showResumeAnalyzer, setShowResumeAnalyzer] = useState(false);
+    const [savedItems, setSavedItems] = useState([]);
 
 
     const openModal = (job) => {
@@ -118,6 +121,29 @@ const Careers = () => {
         };
     }, [isLoggedIn]);
 
+    useEffect(() => {
+        if (!isLoggedIn) {
+            setSavedItems([]);
+            return;
+        }
+
+        let active = true;
+
+        apiClient.get('/saved')
+            .then((response) => {
+                if (!active) return;
+                setSavedItems(response.data?.savedItems || []);
+            })
+            .catch(() => {
+                if (!active) return;
+                setSavedItems([]);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, [isLoggedIn]);
+
 // Fetch recommendations for logged in users
     useEffect(() => {
         if (isLoggedIn) {
@@ -153,6 +179,45 @@ const Careers = () => {
         if (source.includes('hybrid')) return 'hybrid';
         if (source.includes('on-site') || source.includes('onsite') || source.includes('on site')) return 'onsite';
         return 'unspecified';
+    };
+
+    const savedMap = useMemo(() => {
+        return savedItems.reduce((accumulator, item) => {
+            accumulator[`${item.entityType}:${item.entityId}`] = item;
+            return accumulator;
+        }, {});
+    }, [savedItems]);
+
+    const handleToggleSave = async (job) => {
+        if (!isLoggedIn) {
+            toast.error('Please log in to save opportunities');
+            return;
+        }
+
+        const entityId = job?._id || job?.id;
+        if (!entityId) {
+            return;
+        }
+
+        try {
+            const response = await apiClient.post('/saved', {
+                entityType: 'career',
+                entityId
+            });
+
+            if (response.data?.saved) {
+                setSavedItems((currentItems) => [
+                    ...currentItems.filter((item) => !(item.entityType === 'career' && String(item.entityId) === String(entityId))),
+                    response.data.savedItem
+                ]);
+            } else {
+                setSavedItems((currentItems) => currentItems.filter((item) => !(item.entityType === 'career' && String(item.entityId) === String(entityId))));
+            }
+
+            toast.success(response.data?.saved ? 'Job saved' : 'Job removed from saved items');
+        } catch (error) {
+            toast.error(error.response?.data?.message || 'Failed to update saved jobs');
+        }
     };
 
     useEffect(() => {
@@ -407,6 +472,17 @@ const Careers = () => {
                                                         <b><i>Posted by: {j.user?.name || 'Unknown'}</i></b>
                                                     </span>
                                                     <div>
+                                                            {isLoggedIn && (
+                                                                <button
+                                                                    type="button"
+                                                                    className={`btn btn-sm me-2 ${savedMap[`career:${j._id || j.id}`] ? 'btn-warning' : 'btn-outline-secondary'}`}
+                                                                    onClick={() => handleToggleSave(j)}
+                                                                    title={savedMap[`career:${j._id || j.id}`] ? 'Remove saved job' : 'Save job'}
+                                                                >
+                                                                    {savedMap[`career:${j._id || j.id}`] ? <FaBookmark className="me-1" /> : <FaRegBookmark className="me-1" />}
+                                                                    {savedMap[`career:${j._id || j.id}`] ? 'Saved' : 'Save'}
+                                                                </button>
+                                                            )}
                                                         {isAlumnus && (
                                                             <button 
                                                                 className="btn btn-sm btn-success me-2" 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { FaAngleDown, FaCog, FaPowerOff, FaBars } from 'react-icons/fa'; // Import FaBars from react-icons
+import { FaAngleDown, FaBell, FaCog, FaPowerOff, FaBars } from 'react-icons/fa'; // Import FaBars from react-icons
 import { MdDashboard } from "react-icons/md";
 import logo from "../assets/uploads/logo.png";
 import { useAuth } from '../AuthContext';
@@ -8,6 +8,7 @@ import { useTheme } from '../ThemeContext';
 import axios from 'axios';
 import { Fade as Hamburger } from 'hamburger-react'
 import { authUrl, messagesUrl } from '../utils/globalurl';
+import apiClient from '../api/client';
 import { FaMessage } from "react-icons/fa6";
 import ThemeToggle from './ThemeToggle';
 
@@ -21,6 +22,9 @@ const Header = () => {
 const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [name, setName] = useState();
     const [unreadMessages, setUnreadMessages] = useState(0);
+    const [notifications, setNotifications] = useState([]);
+    const [unreadNotifications, setUnreadNotifications] = useState(0);
+    const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
     const navRef = useRef(null);
 
     const toggleMenu = () => {
@@ -38,8 +42,23 @@ useEffect(() => {
         // Fetch unread message count if logged in
         if (isLoggedIn) {
             fetchUnreadCount();
+            fetchNotifications();
         }
     }, [location.state, isLoggedIn]);
+
+    useEffect(() => {
+        if (!isLoggedIn) {
+            setNotifications([]);
+            setUnreadNotifications(0);
+            return;
+        }
+
+        const intervalId = setInterval(() => {
+            fetchNotifications();
+        }, 60000);
+
+        return () => clearInterval(intervalId);
+    }, [isLoggedIn]);
 
     const fetchUnreadCount = async () => {
         try {
@@ -52,6 +71,41 @@ useEffect(() => {
         } catch (error) {
             setUnreadMessages(0);
         }
+    };
+
+    const fetchNotifications = async () => {
+        try {
+            const response = await apiClient.get('/notifications', { params: { limit: 5 } });
+            setNotifications(response.data?.notifications || []);
+            setUnreadNotifications(response.data?.unreadCount || 0);
+        } catch (error) {
+            setNotifications([]);
+            setUnreadNotifications(0);
+        }
+    };
+
+    const handleNotificationOpen = async (notification) => {
+        try {
+            if (!notification.isRead) {
+                await apiClient.patch(`/notifications/${notification._id || notification.id}/read`);
+            }
+        } catch (error) {
+            // Ignore mark-read failures and still navigate.
+        }
+
+        setIsNotificationsOpen(false);
+
+        if (notification.entityType === 'referral' && notification.entityId) {
+            navigate(`/referrals/${notification.entityId}`);
+            return;
+        }
+
+        if (notification.entityType === 'career') {
+            navigate('/jobs');
+            return;
+        }
+
+        navigate('/notifications');
     };
 
     // useEffect(() => {
@@ -94,7 +148,58 @@ useEffect(() => {
                             <li className="nav-item"><Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/gallery")}`} to="/gallery">Gallery</Link></li>
                             <li className="nav-item"><Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/jobs")}`} to="/jobs">Jobs</Link></li>
                             <li className="nav-item"><Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/job-recommendations")}`} to="/job-recommendations">Job Recommendations</Link></li>
-<li className="nav-item"><Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/mentorship")}`} to="/mentorship">Mentorship</Link></li>
+                            <li className="nav-item"><Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/mentorship")}`} to="/mentorship">Mentorship</Link></li>
+                            {isLoggedIn && (
+                                <li className="nav-item dropdown position-relative">
+                                    <button
+                                        type="button"
+                                        className={`nav-link js-scroll-trigger btn btn-link text-decoration-none ${isNotificationsOpen ? 'headnavactive' : ''}`}
+                                        onClick={() => setIsNotificationsOpen((currentValue) => !currentValue)}
+                                    >
+                                        <span className="d-flex align-items-center gap-1">
+                                            <FaBell />
+                                            Alerts
+                                            {unreadNotifications > 0 && (
+                                                <span className="badge bg-danger rounded-pill ms-1">
+                                                    {unreadNotifications > 99 ? '99+' : unreadNotifications}
+                                                </span>
+                                            )}
+                                        </span>
+                                    </button>
+                                    {isNotificationsOpen && (
+                                        <div className="dropdown-menu dropdown-menu-end show p-0 shadow-lg" style={{ minWidth: '340px', maxWidth: '92vw' }}>
+                                            <div className="px-3 py-2 border-bottom d-flex align-items-center justify-content-between">
+                                                <strong>Smart notifications</strong>
+                                                <Link to="/notifications" onClick={() => setIsNotificationsOpen(false)} className="small text-primary text-decoration-none">Open page</Link>
+                                            </div>
+                                            <div style={{ maxHeight: '340px', overflowY: 'auto' }}>
+                                                {notifications.length === 0 ? (
+                                                    <div className="p-3 text-muted small">No notifications yet.</div>
+                                                ) : notifications.map((notification) => (
+                                                    <button
+                                                        key={notification._id || notification.id}
+                                                        type="button"
+                                                        className={`dropdown-item text-start py-3 ${notification.isRead ? '' : 'bg-light'}`}
+                                                        onClick={() => handleNotificationOpen(notification)}
+                                                    >
+                                                        <div className="d-flex align-items-start justify-content-between gap-2">
+                                                            <div>
+                                                                <div className="small text-uppercase text-muted mb-1">{notification.type}</div>
+                                                                <div className="fw-semibold">{notification.title}</div>
+                                                                <div className="small text-muted">{notification.message}</div>
+                                                            </div>
+                                                            {!notification.isRead && <span className="badge bg-warning text-dark">New</span>}
+                                                        </div>
+                                                    </button>
+                                                ))}
+                                            </div>
+                                            <div className="px-3 py-2 border-top bg-light">
+                                                <Link to="/notifications" onClick={() => setIsNotificationsOpen(false)} className="btn btn-sm btn-primary w-100">View all notifications</Link>
+                                            </div>
+                                        </div>
+                                    )}
+                                </li>
+                            )}
                             {isLoggedIn && (
                                 <li className="nav-item">
                                     <Link onClick={toggleMenu} className={`nav-link js-scroll-trigger ${isActive("/messages")}`} to="/messages">

--- a/frontend/src/components/NotificationsPage.jsx
+++ b/frontend/src/components/NotificationsPage.jsx
@@ -1,0 +1,270 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FaBell, FaCheck, FaRegBell, FaRegBookmark } from 'react-icons/fa';
+import { toast } from 'react-toastify';
+import apiClient from '../api/client';
+
+const defaultPreferences = {
+  enabled: false,
+  deadlineApproaching: false,
+  statusChanges: false,
+  betterRecommendations: false,
+  deadlineWindowDays: 3
+};
+
+const NotificationsPage = () => {
+  const navigate = useNavigate();
+  const [notifications, setNotifications] = useState([]);
+  const [preferences, setPreferences] = useState(defaultPreferences);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [savingPreferences, setSavingPreferences] = useState(false);
+
+  useEffect(() => {
+    fetchNotificationData();
+  }, []);
+
+  const fetchNotificationData = async () => {
+    try {
+      setLoading(true);
+      const [notificationsResponse, preferencesResponse] = await Promise.all([
+        apiClient.get('/notifications', { params: { limit: 50 } }),
+        apiClient.get('/notifications/preferences')
+      ]);
+
+      setNotifications(notificationsResponse.data?.notifications || []);
+      setUnreadCount(notificationsResponse.data?.unreadCount || 0);
+      setPreferences({
+        ...defaultPreferences,
+        ...(preferencesResponse.data || {})
+      });
+    } catch (error) {
+      toast.error('Failed to load notifications');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const persistPreferences = async (nextPreferences) => {
+    setSavingPreferences(true);
+    try {
+      const response = await apiClient.patch('/notifications/preferences', nextPreferences);
+      setPreferences({
+        ...defaultPreferences,
+        ...(response.data?.preferences || nextPreferences)
+      });
+      toast.success('Notification preferences updated');
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Failed to update notification preferences');
+    } finally {
+      setSavingPreferences(false);
+    }
+  };
+
+  const handlePreferenceChange = (field, value) => {
+    const nextPreferences = {
+      ...preferences,
+      [field]: value
+    };
+
+    setPreferences(nextPreferences);
+    persistPreferences(nextPreferences);
+  };
+
+  const markAsRead = async (notificationId) => {
+    try {
+      await apiClient.patch(`/notifications/${notificationId}/read`);
+      setNotifications((currentNotifications) => currentNotifications.map((notification) => (
+        notification._id === notificationId || notification.id === notificationId
+          ? { ...notification, isRead: true, readAt: new Date().toISOString() }
+          : notification
+      )));
+      setUnreadCount((count) => Math.max(0, count - 1));
+    } catch (error) {
+      toast.error('Failed to mark notification as read');
+    }
+  };
+
+  const openNotification = async (notification) => {
+    await markAsRead(notification._id || notification.id);
+
+    if (notification.entityType === 'referral' && notification.entityId) {
+      navigate(`/referrals/${notification.entityId}`);
+      return;
+    }
+
+    if (notification.entityType === 'career') {
+      navigate('/jobs');
+      return;
+    }
+
+    navigate('/jobs');
+  };
+
+  if (loading) {
+    return (
+      <div className="container py-5 text-center">
+        <div className="spinner-border text-primary" role="status" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container py-5">
+      <div className="row justify-content-center mb-4">
+        <div className="col-lg-10">
+          <div className="card border-0 shadow-lg overflow-hidden">
+            <div className="card-body p-4 p-md-5 bg-gradient-primary text-white" style={{ background: 'linear-gradient(135deg, #0f172a 0%, #1d4ed8 55%, #0f766e 100%)' }}>
+              <div className="d-flex flex-column flex-md-row justify-content-between align-items-start gap-3">
+                <div>
+                  <div className="d-inline-flex align-items-center gap-2 bg-white bg-opacity-10 px-3 py-2 rounded-pill mb-3">
+                    <FaBell /> Smart notifications
+                  </div>
+                  <h1 className="display-6 fw-bold mb-2">Notification Center</h1>
+                  <p className="mb-0 text-white-75">Saved opportunities, deadline reminders, status changes, and stronger matches land here.</p>
+                </div>
+                <div className="text-md-end">
+                  <div className="fs-3 fw-bold">{unreadCount}</div>
+                  <div className="text-white-75">Unread notifications</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="row g-4">
+        <div className="col-lg-4">
+          <div className="card shadow-sm border-0 h-100">
+            <div className="card-body p-4">
+              <div className="d-flex align-items-center justify-content-between mb-3">
+                <h2 className="h5 mb-0">Notification Preferences</h2>
+                <FaRegBell className="text-primary" />
+              </div>
+              <p className="text-muted small mb-4">Defaults stay off until you turn them on.</p>
+
+              <div className="form-check form-switch mb-3">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={preferences.enabled}
+                  onChange={(event) => handlePreferenceChange('enabled', event.target.checked)}
+                  disabled={savingPreferences}
+                  id="notifications-enabled"
+                />
+                <label className="form-check-label" htmlFor="notifications-enabled">
+                  Enable smart notifications
+                </label>
+              </div>
+
+              <div className="form-check form-switch mb-3">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={preferences.deadlineApproaching}
+                  onChange={(event) => handlePreferenceChange('deadlineApproaching', event.target.checked)}
+                  disabled={savingPreferences}
+                  id="deadline-approaching"
+                />
+                <label className="form-check-label" htmlFor="deadline-approaching">
+                  Deadline approaching alerts
+                </label>
+              </div>
+
+              <div className="form-check form-switch mb-3">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={preferences.statusChanges}
+                  onChange={(event) => handlePreferenceChange('statusChanges', event.target.checked)}
+                  disabled={savingPreferences}
+                  id="status-changes"
+                />
+                <label className="form-check-label" htmlFor="status-changes">
+                  Status change alerts
+                </label>
+              </div>
+
+              <div className="form-check form-switch mb-4">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={preferences.betterRecommendations}
+                  onChange={(event) => handlePreferenceChange('betterRecommendations', event.target.checked)}
+                  disabled={savingPreferences}
+                  id="better-recommendations"
+                />
+                <label className="form-check-label" htmlFor="better-recommendations">
+                  Better recommendation alerts
+                </label>
+              </div>
+
+              <label className="form-label small text-muted" htmlFor="deadline-window-days">
+                Deadline window in days
+              </label>
+              <input
+                id="deadline-window-days"
+                type="number"
+                min="1"
+                max="30"
+                className="form-control"
+                value={preferences.deadlineWindowDays}
+                onChange={(event) => handlePreferenceChange('deadlineWindowDays', Number(event.target.value))}
+                disabled={savingPreferences}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="col-lg-8">
+          <div className="card shadow-sm border-0">
+            <div className="card-body p-4">
+              <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+                <div>
+                  <h2 className="h5 mb-1">Recent notifications</h2>
+                  <p className="text-muted small mb-0">Tap an item to mark it read and jump to the related opportunity.</p>
+                </div>
+                <span className="badge bg-light text-dark border">{notifications.length} total</span>
+              </div>
+
+              {notifications.length === 0 ? (
+                <div className="text-center py-5 text-muted">
+                  <FaRegBookmark className="fs-1 mb-3" />
+                  <p className="mb-0">No notifications yet. Save a few opportunities to start receiving smart updates.</p>
+                </div>
+              ) : (
+                <div className="d-grid gap-3">
+                  {notifications.map((notification) => (
+                    <button
+                      key={notification._id || notification.id}
+                      type="button"
+                      onClick={() => openNotification(notification)}
+                      className={`text-start border rounded-4 p-4 bg-white w-100 ${notification.isRead ? 'opacity-75' : 'shadow-sm border-primary'}`}
+                      style={{ transition: 'transform 0.2s ease, box-shadow 0.2s ease' }}
+                    >
+                      <div className="d-flex justify-content-between align-items-start gap-3">
+                        <div>
+                          <div className="d-flex align-items-center gap-2 mb-2">
+                            <span className={`badge ${notification.isRead ? 'bg-secondary' : 'bg-primary'}`}>
+                              {notification.type}
+                            </span>
+                            {!notification.isRead && <span className="badge bg-warning text-dark">Unread</span>}
+                          </div>
+                          <h3 className="h6 mb-2">{notification.title}</h3>
+                          <p className="mb-0 text-muted">{notification.message}</p>
+                        </div>
+                        {!notification.isRead && <FaCheck className="text-primary mt-1 flex-shrink-0" />}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationsPage;

--- a/frontend/src/components/ReferralDetail.jsx
+++ b/frontend/src/components/ReferralDetail.jsx
@@ -20,6 +20,7 @@ const ReferralDetail = () => {
 
   const currentUserId = localStorage.getItem('user_id');
   const currentUserType = (localStorage.getItem('user_type') || '').toLowerCase();
+  const isAdmin = currentUserType === 'admin';
 
   const getDocId = (value) => value?._id || value?.id || value;
 
@@ -229,6 +230,25 @@ const ReferralDetail = () => {
 
   const getMessageSide = (message) => getDocId(message.sender) === currentUserId ? 'self' : 'other';
 
+  const bonusComputation = referral?.bonusComputation || {};
+  const bonusStatus = bonusComputation.status || 'pending';
+  const bonusAmount = Number(bonusComputation.amount || 0);
+  const bonusBadgeClass = bonusStatus === 'eligible'
+    ? 'bg-green-100 text-green-800'
+    : bonusStatus === 'not-eligible'
+      ? 'bg-red-100 text-red-800'
+      : 'bg-yellow-100 text-yellow-800';
+
+  const handleComputeBonus = async () => {
+    try {
+      const response = await apiClient.post(`/api/referrals/${id}/compute-bonus`);
+      setReferral(response.data?.referral || referral);
+      toast.success('Referral bonus computed');
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Failed to compute bonus');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 py-12">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -266,6 +286,46 @@ const ReferralDetail = () => {
                 }`}>
                   {new Date(referral.deadline).toLocaleDateString()}
                 </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="mb-8">
+          <div className="bg-white rounded-2xl shadow-lg p-6 border border-gray-100">
+            <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-3 mb-2">
+                  <h2 className="text-xl font-bold text-gray-900">Referral Bonus</h2>
+                  <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold ${bonusBadgeClass}`}>
+                    {bonusStatus.replace('-', ' ')}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 mb-2">
+                  Payout on {String(referral.bonusPolicy?.payoutOn || 'filled').toUpperCase()} with company rules for {referral.company}.
+                </p>
+                <div className="flex flex-wrap gap-3 text-sm text-gray-700">
+                  <span className="px-3 py-1 rounded-full bg-gray-100">Base: ${Number(referral.referralBonus || 0)}</span>
+                  <span className="px-3 py-1 rounded-full bg-gray-100">Computed: ${bonusAmount}</span>
+                  {bonusComputation.deadlinePenaltyPercent > 0 && (
+                    <span className="px-3 py-1 rounded-full bg-yellow-100 text-yellow-800">
+                      Deadline penalty: {bonusComputation.deadlinePenaltyPercent}%
+                    </span>
+                  )}
+                </div>
+                <p className="mt-3 text-sm text-gray-600">
+                  {bonusComputation.reason || 'Bonus has not been computed yet.'}
+                </p>
+              </div>
+
+              {isAdmin && (
+                <button
+                  type="button"
+                  onClick={handleComputeBonus}
+                  className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white shadow-lg transition-colors hover:bg-blue-700"
+                >
+                  Compute Bonus
+                </button>
               )}
             </div>
           </div>

--- a/frontend/src/components/ReferralList.jsx
+++ b/frontend/src/components/ReferralList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { FaBookmark, FaRegBookmark } from 'react-icons/fa';
 import apiClient from '../api/client';
 import { useAuth } from '../AuthContext';
 import { toast } from 'react-toastify';
@@ -12,11 +13,35 @@ const ReferralList = () => {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('open');
   const [page, setPage] = useState(1);
+  const [savedItems, setSavedItems] = useState([]);
   const limit = 10;
 
   useEffect(() => {
     fetchReferrals();
   }, [statusFilter, page]);
+
+  useEffect(() => {
+    if (!user) {
+      setSavedItems([]);
+      return;
+    }
+
+    let active = true;
+
+    apiClient.get('/saved')
+      .then((response) => {
+        if (!active) return;
+        setSavedItems(response.data?.savedItems || []);
+      })
+      .catch(() => {
+        if (!active) return;
+        setSavedItems([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [user]);
 
   const fetchReferrals = async () => {
     try {
@@ -53,6 +78,38 @@ const ReferralList = () => {
     ref.jobTitle.toLowerCase().includes(search.toLowerCase()) ||
     ref.company.toLowerCase().includes(search.toLowerCase())
   );
+
+  const savedMap = savedItems.reduce((accumulator, item) => {
+    accumulator[`${item.entityType}:${item.entityId}`] = item;
+    return accumulator;
+  }, {});
+
+  const handleToggleSave = async (referral) => {
+    if (!user) {
+      toast.error('Please log in to save opportunities');
+      return;
+    }
+
+    try {
+      const response = await apiClient.post('/saved', {
+        entityType: 'referral',
+        entityId: referral._id
+      });
+
+      if (response.data?.saved) {
+        setSavedItems((currentItems) => [
+          ...currentItems.filter((item) => !(item.entityType === 'referral' && String(item.entityId) === String(referral._id))),
+          response.data.savedItem
+        ]);
+      } else {
+        setSavedItems((currentItems) => currentItems.filter((item) => !(item.entityType === 'referral' && String(item.entityId) === String(referral._id))));
+      }
+
+      toast.success(response.data?.saved ? 'Referral saved' : 'Referral removed from saved items');
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Failed to update saved referrals');
+    }
+  };
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
@@ -169,6 +226,15 @@ const ReferralList = () => {
                 </Link>
                 {user && (
                   <button
+                    onClick={() => handleToggleSave(referral)}
+                    className={`py-3 px-4 rounded-xl font-semibold transition-all duration-200 shadow-lg hover:shadow-xl ${savedMap[`referral:${referral._id}`] ? 'bg-yellow-500 hover:bg-yellow-600 text-white' : 'bg-white hover:bg-gray-50 text-gray-700 border border-gray-200'}`}
+                    title={savedMap[`referral:${referral._id}`] ? 'Remove saved referral' : 'Save referral'}
+                  >
+                    {savedMap[`referral:${referral._id}`] ? <FaBookmark /> : <FaRegBookmark />}
+                  </button>
+                )}
+                {user && (
+                  <button
                     onClick={() => {
                       // Quick apply confirmation
                       if (confirm('Apply for this referral?')) {
@@ -191,7 +257,8 @@ const ReferralList = () => {
                 </div>
               </div>
             </div>
-          ))}
+          ))
+        )}
 
       </div>
 

--- a/frontend/src/config/routes.js
+++ b/frontend/src/config/routes.js
@@ -94,6 +94,11 @@ export const privateRoutes = [
     component: "ReferralDetail", 
     roles: ["alumnus", "student", "admin"] 
   },
+  {
+    path: "/notifications",
+    component: "NotificationsPage",
+    roles: ["admin", "alumnus", "student"]
+  },
 ];
 
 


### PR DESCRIPTION
Implemented the moderation flow across the backend and the existing admin referrals page. The backend now records every moderation action in a new audit collection, exposes admin endpoints for flag, hide, restore, and suspend-poster, and hides moderated referrals from normal referral queries. I also added poster suspension enforcement in the auth middleware so suspended posters cannot keep creating referral content. Relevant files: referral.controller.js, adminReferral.routes.js, ReferralModerationAction.model.js, JobReferral.model.js, auth.middleware.js, AdminReferrals.jsx.

Backend validation passed with npm test. The frontend build is still blocked by an unrelated CSS syntax error in index.css, so I did not touch that file.

closes #206