### PR TITLE
fix: Referral “accept” closes the whole referral 

### DIFF
--- a/backend/controllers/referral.controller.js
+++ b/backend/controllers/referral.controller.js
@@ -303,12 +303,14 @@ async function acceptReferral(req, res, next) {
       return res.status(404).json({ message: 'Applicant not found' });
     }
 
+    if (referral.status !== 'open') {
+      return res.status(400).json({ message: 'Referral is no longer open' });
+    }
+
     const applicantUser = await User.findById(applicantId).select('_id name');
 
     referral.applicants[applicantIndex].status = 'accepted';
     referral.applicants[applicantIndex].acceptedAt = new Date();
-    referral.status = 'filled'; // Close after accept
-    referral.filledAt = new Date();
 
     appendTimelineEvent(referral, {
       action: 'accepted',
@@ -320,18 +322,6 @@ async function acceptReferral(req, res, next) {
       applicant: applicantUser?._id || applicantId,
       applicantName: applicantUser?.name,
       details: `${applicantUser?.name || 'Applicant'} was accepted`
-    });
-
-    appendTimelineEvent(referral, {
-      action: 'filled',
-      status: 'filled',
-      scope: 'referral',
-      actor: currentUser,
-      actorName: currentUser?.name,
-      actorType: currentUser?.type,
-      applicant: applicantUser?._id || applicantId,
-      applicantName: applicantUser?.name,
-      details: 'Referral marked as filled'
     });
 
     await referral.save();

--- a/backend/test/referral.acceptReferral.test.js
+++ b/backend/test/referral.acceptReferral.test.js
@@ -1,0 +1,106 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { acceptReferral } = require('../controllers/referral.controller');
+const { JobReferral, User } = require('../models/Index');
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    }
+  };
+}
+
+test('acceptReferral keeps the referral open after accepting one applicant', async () => {
+  const originalFindById = JobReferral.findById;
+  const originalUserFindById = User.findById;
+
+  const referral = {
+    _id: 'referral-1',
+    status: 'open',
+    filledAt: null,
+    postedBy: {
+      toString: () => 'owner-1'
+    },
+    bonusPolicy: {
+      payoutOn: 'accepted'
+    },
+    timeline: [],
+    applicants: [
+      {
+        user: 'applicant-1',
+        status: 'pending',
+        acceptedAt: null,
+        rejectedAt: null
+      },
+      {
+        user: 'applicant-2',
+        status: 'pending',
+        acceptedAt: null,
+        rejectedAt: null
+      }
+    ],
+    save: async () => {},
+    populate: async function populate() {
+      return this;
+    }
+  };
+
+  let referralFindByIdCalls = 0;
+
+  JobReferral.findById = async (id) => {
+    referralFindByIdCalls += 1;
+    assert.equal(id, 'referral-1');
+    return referral;
+  };
+
+  User.findById = (id) => {
+    if (id === 'owner-1') {
+      return {
+        select: async () => ({ _id: 'owner-1', name: 'Owner User', type: 'alumnus' })
+      };
+    }
+
+    if (id === 'applicant-1') {
+      return {
+        select: async () => ({ _id: 'applicant-1', name: 'Ada Lovelace' })
+      };
+    }
+
+    throw new Error(`Unexpected user lookup: ${id}`);
+  };
+
+  try {
+    const req = {
+      params: { id: 'referral-1', applicantId: 'applicant-1' },
+      user: { id: 'owner-1' }
+    };
+    const res = createResponse();
+
+    await acceptReferral(req, res, () => {});
+
+    assert.equal(res.statusCode, 200);
+    assert.deepStrictEqual(res.payload, {
+      message: 'Applicant accepted successfully',
+      referral
+    });
+    assert.equal(referral.status, 'open');
+    assert.equal(referral.filledAt, null);
+    assert.equal(referral.applicants[0].status, 'accepted');
+    assert.ok(referral.applicants[0].acceptedAt instanceof Date);
+    assert.equal(referral.applicants[1].status, 'pending');
+    assert.deepStrictEqual(referral.timeline.map((event) => event.action), ['accepted']);
+    assert.ok(referralFindByIdCalls >= 2);
+  } finally {
+    JobReferral.findById = originalFindById;
+    User.findById = originalUserFindById;
+  }
+});


### PR DESCRIPTION
The referral accept flow now leaves the referral open instead of marking it filled on the first acceptance, and it rejects accept attempts once the referral has already been explicitly closed or filled. The change is in referral.controller.js.

I also added a regression test that verifies accepting one applicant keeps the referral open and preserves the other applicants’ statuses in referral.acceptReferral.test.js.

Validation passed with node --test backend/test/referral.acceptReferral.test.js.


closes #232