### PR TITLE
fix(#262): add per-IP rate limiting to auth endpoints

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -1,16 +1,45 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const { login, signup, logout, session, requestPasswordReset, verifyOtp, resetPassword } = require('../controllers/auth.controller');
 const { authenticate } = require('../middlewares/auth.middleware');
 
 const router = express.Router();
 
-router.post('/login', login);
-router.post('/signup', signup);
+// Strict rate limiter for credential and OTP endpoints.
+// Limits brute-force password attacks, OTP guessing, and email enumeration.
+const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many attempts. Please try again in 15 minutes.' },
+});
+
+// Looser limiter for account creation to prevent bulk signup abuse.
+const signupLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many signup attempts. Please try again later.' },
+});
+
+// OTP and password-reset endpoints share the same tight window as login.
+const otpLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many attempts. Please try again in 15 minutes.' },
+});
+
+router.post('/login', loginLimiter, login);
+router.post('/signup', signupLimiter, signup);
 router.post('/logout', logout);
 router.get('/session', authenticate, session);
 
-router.post('/forgot-password', requestPasswordReset);
-router.post('/verify-otp', verifyOtp);
-router.post('/reset-password', resetPassword);
+router.post('/forgot-password', otpLimiter, requestPasswordReset);
+router.post('/verify-otp', otpLimiter, verifyOtp);
+router.post('/reset-password', otpLimiter, resetPassword);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Adds express-rate-limit middleware to all authentication endpoints to prevent brute-force attacks, OTP guessing, and bulk account creation.

## Related Issue

Closes #262

## Type of Change

- [x] Security fix

## Root Cause

\`POST /auth/login\`, \`/auth/signup\`, \`/auth/forgot-password\`, \`/auth/verify-otp\`, and \`/auth/reset-password\` had no rate limiting. An attacker could send unlimited requests to brute-force passwords, enumerate email addresses (the login controller distinguishes \`Invalid Credentials\` from \`User not found\`), exhaust OTP delivery, or register thousands of dummy accounts.

## What Changed

- \`backend/routes/auth.routes.js\`: added three \`express-rate-limit\` middlewares (the package is already listed in \`package.json\`):
  - \`loginLimiter\`: 10 requests per 15 minutes for \`/login\`
  - \`signupLimiter\`: 5 requests per hour for \`/signup\`
  - \`otpLimiter\`: 10 requests per 15 minutes for \`/forgot-password\`, \`/verify-otp\`, and \`/reset-password\`

## Testing

- [ ] More than 10 \`/login\` requests within 15 minutes from the same IP returns HTTP 429
- [ ] More than 5 \`/signup\` requests within an hour returns HTTP 429
- [ ] Normal requests within the limit succeed without change

## Checklist

- [x] No hardcoded secrets or credentials
- [x] No new dependencies (express-rate-limit already in package.json)
- [x] Single focused change