### PR TITLE
fix(#263,#264,#265): fix forum author impersonation, missing ownership checks, and unbounded query

### DIFF
--- a/backend/controllers/forum.controller.js
+++ b/backend/controllers/forum.controller.js
@@ -1,45 +1,84 @@
 const {ForumTopic,User}=require('../models/Index');
 
-// list all forum topics with user names
+// Maximum number of forum topics returned per page (#265).
+const FORUM_PAGE_SIZE = 20;
+
+// list all forum topics with pagination (#265)
 async function listForums(req, res, next) {
     try {
-        const forums = await ForumTopic.find()
-            .populate('user', 'name')
-            .populate('comments.user', 'name')
-            .sort({ createdAt: -1 });
-        res.json(forums);
+        const page = Math.max(1, parseInt(req.query.page) || 1);
+        const limit = Math.min(FORUM_PAGE_SIZE, parseInt(req.query.limit) || FORUM_PAGE_SIZE);
+        const skip = (page - 1) * limit;
+
+        const [forums, total] = await Promise.all([
+            ForumTopic.find()
+                .populate('user', 'name')
+                .populate('comments.user', 'name')
+                .sort({ createdAt: -1 })
+                .skip(skip)
+                .limit(limit),
+            ForumTopic.countDocuments(),
+        ]);
+
+        res.json({
+            forums,
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit),
+        });
     } catch (err) { next(err); }
 }
-// add new forum topic
+
+// add new forum topic - author derived from verified session, not request body (#263)
 async function addForum(req, res, next) {
     try {
         const topicData = {
             title: req.body.title,
             description: req.body.description,
-            user: req.body.user_id || req.body.user
+            // Always use the authenticated caller's ID. Never trust client-supplied
+            // user_id or user fields, which would allow author impersonation.
+            user: req.user.id || req.user._id,
         };
         const topic = await ForumTopic.create(topicData);
         res.status(201).json(topic);
     } catch (err) { next(err); }
 }
 
-// update forum topic
+// update forum topic - only the original author may edit (#264)
 async function updateForum(req, res, next) {
     try {
-        const updateData = { ...req.body };
-        delete updateData._id;
-        delete updateData.id;
-        if (req.body.user_id) {
-            updateData.user = req.body.user_id;
-            delete updateData.user_id;
+        const topic = await ForumTopic.findById(req.params.id);
+        if (!topic) {
+            return res.status(404).json({ message: 'Topic not found' });
         }
-        await ForumTopic.findByIdAndUpdate(req.params.id, updateData, { new: true });
+        // Ownership check: prevent any authenticated user from editing another user's topic.
+        const callerId = String(req.user.id || req.user._id);
+        if (String(topic.user) !== callerId) {
+            return res.status(403).json({ message: 'Not authorised to update this topic' });
+        }
+        // Only allow updating title and description; never allow reassigning the author.
+        const { title, description } = req.body;
+        await ForumTopic.findByIdAndUpdate(
+            req.params.id,
+            { title, description },
+            { new: true }
+        );
         res.json({ message: 'Updated' });
     } catch (err) { next(err); }
 }
-// delete forum topic
+
+// delete forum topic - only the original author may delete (#264)
 async function deleteForum(req, res, next) {
     try {
+        const topic = await ForumTopic.findById(req.params.id);
+        if (!topic) {
+            return res.status(404).json({ message: 'Topic not found' });
+        }
+        const callerId = String(req.user.id || req.user._id);
+        if (String(topic.user) !== callerId) {
+            return res.status(403).json({ message: 'Not authorised to delete this topic' });
+        }
         await ForumTopic.findByIdAndDelete(req.params.id);
         res.json({ message: 'Deleted' });
     } catch (err) { next(err); }


### PR DESCRIPTION
## Summary

Fixes three related security and reliability bugs in the forum controller.

## Related Issues

Closes #263
Closes #264
Closes #265

## Type of Change

- [x] Security fix
- [x] Bug fix

## Root Cause

**#263 (Author impersonation):** \`addForum\` read the topic author from \`req.body.user_id\` or \`req.body.user\`. Any authenticated user could create a topic attributed to another user by supplying their ObjectId.

**#264 (Missing ownership check):** \`updateForum\` and \`deleteForum\` verified only that the caller was authenticated. Any logged-in user could edit or delete any forum topic. \`updateForum\` also spread the full \`req.body\` allowing field injection including author reassignment.

**#265 (Unbounded query):** \`listForums\` fetched every \`ForumTopic\` document with no limit or skip, producing unbounded database queries and response sizes as topic count grows.

## What Changed

- \`backend/controllers/forum.controller.js\`:
  - \`addForum\`: replaced \`req.body.user_id || req.body.user\` with \`req.user.id\`.
  - \`updateForum\`: added ownership check; restricted updates to \`title\` and \`description\` only.
  - \`deleteForum\`: added ownership check before deleting.
  - \`listForums\`: added \`?page\` and \`?limit\` query parameters (max 20 per page) with \`countDocuments\` and pagination metadata in the response.

## Testing

- [ ] Creating a forum topic with a \`user_id\` body field does not change authorship
- [ ] Editing or deleting another user's topic returns HTTP 403
- [ ] \`GET /forums?page=1&limit=10\` returns at most 10 topics with pagination metadata

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change per issue