### PR TITLE
fix(forum): derive topic author from JWT session instead of request body

### DIFF
--- a/backend/controllers/forum.controller.js
+++ b/backend/controllers/forum.controller.js
@@ -10,13 +10,16 @@ async function listForums(req, res, next) {
         res.json(forums);
     } catch (err) { next(err); }
 }
-// add new forum topic
+// add new forum topic - author is always the authenticated caller (#263)
 async function addForum(req, res, next) {
     try {
         const topicData = {
             title: req.body.title,
             description: req.body.description,
-            user: req.body.user_id || req.body.user
+            // Always derive the author from the verified JWT payload.
+            // Trusting req.body.user_id or req.body.user allows any
+            // authenticated caller to impersonate another user.
+            user: req.user.id || req.user._id,
         };
         const topic = await ForumTopic.create(topicData);
         res.status(201).json(topic);


### PR DESCRIPTION
## Summary

Closes #263

`addForum` in `backend/controllers/forum.controller.js` used `req.body.user_id || req.body.user` as the topic author. Any authenticated caller could supply a different user's MongoDB ObjectId in the request body and have the forum topic attributed to that user, with the victim's name shown as the author.

## What Changed

`backend/controllers/forum.controller.js` only:

- Replaced the client-supplied `user_id`/`user` fields with `req.user.id || req.user._id` (the verified JWT payload).
- The author is now always the authenticated caller regardless of what the request body contains.

## Testing

1. Log in as User A. POST `/api/v1/forums` with `user_id` set to User B's ID. Verify the created topic shows User A as the author.
2. Confirm the title and description are saved correctly.

## Type of Change

- [x] Bug fix (security)

*NSoC '26 contribution*