### PR TITLE
fix(forum): add pagination to listForums to prevent unbounded database queries

### DIFF
--- a/backend/controllers/forum.controller.js
+++ b/backend/controllers/forum.controller.js
@@ -1,13 +1,32 @@
 const {ForumTopic,User}=require('../models/Index');
 
-// list all forum topics with user names
+// Maximum forum topics returned per page (#265)
+const FORUM_PAGE_SIZE = 20;
+
+// list forum topics with cursor-based pagination (#265)
 async function listForums(req, res, next) {
     try {
-        const forums = await ForumTopic.find()
-            .populate('user', 'name')
-            .populate('comments.user', 'name')
-            .sort({ createdAt: -1 });
-        res.json(forums);
+        const page = Math.max(1, parseInt(req.query.page) || 1);
+        const limit = Math.min(FORUM_PAGE_SIZE, parseInt(req.query.limit) || FORUM_PAGE_SIZE);
+        const skip = (page - 1) * limit;
+
+        const [forums, total] = await Promise.all([
+            ForumTopic.find()
+                .populate('user', 'name')
+                .populate('comments.user', 'name')
+                .sort({ createdAt: -1 })
+                .skip(skip)
+                .limit(limit),
+            ForumTopic.countDocuments(),
+        ]);
+
+        res.json({
+            forums,
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit),
+        });
     } catch (err) { next(err); }
 }
 // add new forum topic


### PR DESCRIPTION
## Summary

Closes #265

`listForums` fetched every `ForumTopic` document with an unparameterised `find()`. As the forum grows, each `GET /api/v1/forums` loads the full collection into memory, serialises it to JSON, and sends it to the client. This causes unbounded query time, large response bodies, and elevated heap usage under concurrent requests.

## What Changed

`backend/controllers/forum.controller.js` only:

- Added `page` and `limit` query parameters. `page` defaults to `1`. `limit` defaults to `FORUM_PAGE_SIZE` (20) and is capped at that value to prevent callers from bypassing the limit.
- The response now includes `{ forums, page, limit, total, totalPages }`.
- A parallel `countDocuments()` query provides the total count for client-side pagination UI.

## Testing

1. `GET /api/v1/forums` returns at most 20 topics with pagination metadata.
2. `GET /api/v1/forums?page=2&limit=10` returns the correct page.
3. A limit value larger than 20 is clamped to 20.

## Type of Change

- [x] Bug fix (performance)

*NSoC '26 contribution*