### PR TITLE
fix(messages): enforce max content length in sendMessage

### DIFF
--- a/backend/controllers/directMessage.controller.js
+++ b/backend/controllers/directMessage.controller.js
@@ -13,6 +13,27 @@ const sendMessage = async (req, res) => {
       return res.status(400).json({ error: 'Receiver ID and content are required' });
     }
 
+    // Enforce a maximum message length to prevent oversized document storage
+    // and disproportionately large inbox payloads. The global express.json
+    // limit (100 KB) is too permissive for a single chat message.
+    const MAX_CONTENT_LENGTH = 2000;
+    if (typeof content !== 'string' || content.length > MAX_CONTENT_LENGTH) {
+      return res.status(400).json({
+        error: `Message content must not exceed ${MAX_CONTENT_LENGTH} characters`,
+      });
+    }
+
+    // Validate fileUrl when present: only allow http/https scheme to prevent
+    // javascript: URI injection that a frontend might render as a clickable link.
+    if (fileUrl && !/^https?:\/\//i.test(fileUrl)) {
+      return res.status(400).json({ error: 'fileUrl must be an http or https URL' });
+    }
+
+    // fileName may not contain path separators.
+    if (fileName && /[/\\]/.test(fileName)) {
+      return res.status(400).json({ error: 'Invalid fileName' });
+    }
+
     // Check if receiver exists
     const receiver = await User.findById(receiverId);
     if (!receiver) {


### PR DESCRIPTION
## Summary

Closes #266

`sendMessage` in `backend/controllers/directMessage.controller.js` validated only that `content` was non-empty. The global `express.json({ limit: '100kb' })` body limit is too permissive for a single chat message. A caller could store and transmit up to 100 KB in every message document, causing oversized inbox payloads and MongoDB document bloat.

## What Changed

`backend/controllers/directMessage.controller.js` only:

- Added a `MAX_CONTENT_LENGTH` constant (2000 characters).
- A type check (`typeof content !== 'string'`) and length check (`content.length > MAX_CONTENT_LENGTH`) return `400` before any database write.
- Added `fileUrl` scheme validation (http/https only) to prevent javascript: URI injection.
- Added `fileName` path-separator check to prevent path traversal via the file name field.

## Testing

1. POST `/api/v1/messages` with `content` longer than 2000 characters returns `400`.
2. Normal messages within the limit send successfully.
3. A `fileUrl` with `javascript:` scheme returns `400`.

## Type of Change

- [x] Bug fix

*NSoC '26 contribution*