### PR TITLE
[BUG]: Owner message recipient resolution can send incorrect recipientId

### DIFF
--- a/frontend/src/components/ReferralDetail.jsx
+++ b/frontend/src/components/ReferralDetail.jsx
@@ -65,14 +65,15 @@ const ReferralDetail = () => {
       return;
     }
 
-    if (isOwner && applicants.length > 0 && !selectedRecipientId) {
-      setSelectedRecipientId(getDocId(applicants[0].user));
+    if (isOwner) {
+      if (applicants.length > 0 && !selectedRecipientId) {
+        setSelectedRecipientId(getDocId(applicants[0].user));
+      }
+      return;
     }
 
-    if (!isOwner) {
-      setSelectedRecipientId(getDocId(referral.postedBy));
-    }
-  }, [referral, applicants, isOwner, selectedRecipientId]);
+    setSelectedRecipientId(getDocId(referral.postedBy));
+  }, [referral, applicants, isOwner]);
 
   const fetchReferral = async () => {
     try {
@@ -487,7 +488,7 @@ const ReferralDetail = () => {
 
                     <button
                       type="submit"
-                      disabled={sendingMessage}
+                      disabled={sendingMessage || (isOwner && !selectedRecipientId)}
                       className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white shadow-lg transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {sendingMessage ? 'Sending...' : 'Send Message'}


### PR DESCRIPTION
Implemented the frontend fix in frontend/src/components/ReferralDetail.jsx to prevent sending a message with an incorrect recipientId when the owner’s applicant list hasn’t loaded yet.

Changes made
Recipient selection race fix: updated the owner useEffect so it only sets selectedRecipientId when applicants.length > 0 (no fallback to applicants[0] while empty).
Send button disabled until resolved (owner only):
disabled={sendingMessage || (isOwner && !selectedRecipientId)}
Guard in handleSendMessage: already present, kept intact so owner posting cannot POST without a truthy recipientId.
Result
npm run build (Vite) succeeded after the changes.


closes #250