### PR TITLE
fix(auth): return HTTP 401 for invalid login credentials

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -18,11 +18,11 @@ async function login(req, res, next) {
         const { email, password } = req.body;
         const user = await User.findOne({ email });
         if (!user) {
-            return res.json({ loginStatus: false, Error: 'Invalid Credentials' });
+            return res.status(401).json({ loginStatus: false, Error: 'Invalid Credentials' });
         }
         const match = await bycrypt.compare(password, user.password);
         if (!match) {
-            return res.json({ loginStatus: false, Error: 'Invalid Credentials' });
+            return res.status(401).json({ loginStatus: false, Error: 'Invalid Credentials' });
         }
         const token = jwt.sign({ id: user._id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '1d' });
         res.cookie('token', token, cookieOptions);


### PR DESCRIPTION
## Related Issue

Closes #279

## Problem

The login controller returned `res.json(...)` with no explicit status code on both failure paths, which defaults to HTTP 200 OK:

```js
if (!user) {
    return res.json({ loginStatus: false, Error: 'Invalid Credentials' });
}
if (!match) {
    return res.json({ loginStatus: false, Error: 'Invalid Credentials' });
}
```

HTTP 200 signals a successful request. Security middleware, CDN caches, analytics tools, and client interceptors that check the status code will misclassify failed logins as successes, breaking standard error-handling conventions.

## Fix

Added `res.status(401)` to both failure returns:

```js
return res.status(401).json({ loginStatus: false, Error: 'Invalid Credentials' });
```

HTTP 401 Unauthorized is the correct status for a failed authentication attempt.

## Files Changed

| File | Change |
|---|---|
| `backend/controllers/auth.controller.js` | Add `.status(401)` to both failed-login response paths |

## Testing

- Valid credentials: HTTP 200, `loginStatus: true`.
- Wrong password: HTTP 401, `loginStatus: false`.
- Unknown email: HTTP 401, `loginStatus: false`.

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!