### PR TITLE
fix(auth): remove email enumeration leak from signup duplicate check

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -87,7 +87,7 @@ async function signup(req, res, next) {
         //check for existing email
         const existing = await User.findOne({ email });
         if (existing) {
-            return res.json({ email: existing.email });
+            return res.status(409).json({ error: 'An account with this email already exists' });
         }
         const hashed = await bycrypt.hash(password, 10);
         let user;


### PR DESCRIPTION
## Related Issue

Closes #280

## Problem

When a signup used an already-registered email, the endpoint echoed the existing user's email and returned HTTP 200:

```js
const existing = await User.findOne({ email });
if (existing) {
    return res.json({ email: existing.email });
}
```

This let any caller enumerate registered addresses by attempting signup and checking whether the response body contained an `email` field. The response also used the wrong HTTP status code.

## Fix

```js
if (existing) {
    return res.status(409).json({ error: 'An account with this email already exists' });
}
```

- HTTP 409 Conflict is the correct code for a resource creation attempt blocked by a uniqueness constraint.
- The response body no longer includes any data derived from the existing user document.

## Files Changed

| File | Change |
|---|---|
| `backend/controllers/auth.controller.js` | Replace `res.json({ email: existing.email })` with `res.status(409).json({ error: '...' })` |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!