### PR TITLE
fix(auth): persist current_year when creating a student account

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -131,6 +131,7 @@ async function signup(req, res, next) {
                 student_bio: {
                     gender: req.body.gender || 'male',
                     enrollment_year: req.body.enrollment_year || new Date().getFullYear(),
+                    current_year: Number(req.body.current_year),
                     course: course_id,
                     roll_number: req.body.roll_number || null,
                     avatar: ''


### PR DESCRIPTION
## Related Issue

Closes #277

## Problem

The student signup path validated `current_year` (range 1 to 6) but the field was absent from the `student_bio` object passed to `User.create`:

```js
student_bio: {
    gender: req.body.gender || 'male',
    enrollment_year: req.body.enrollment_year || new Date().getFullYear(),
    course: course_id,
    roll_number: req.body.roll_number || null,
    avatar: ''
    // current_year is missing
}
```

Every student account was stored with `current_year` as `undefined` in the database even though the client submitted a valid value and the `studentBioSchema` includes the field.

## Fix

Added `current_year: Number(req.body.current_year)` to the `student_bio` object. `Number()` is used for consistency with the numeric type expected by the schema.

## Files Changed

| File | Change |
|---|---|
| `backend/controllers/auth.controller.js` | Add `current_year` field to `student_bio` in `User.create` |

## Testing

- POST signup with `userType: student`, `current_year: 3`. The saved document has `student_bio.current_year === 3`.
- The login response already included `current_year` in the `student_bio` payload, so frontend consumers will now receive the correct value.

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!