### PR TITLE
fix(events): prevent duplicate participation in participateEvent

### DIFF
--- a/backend/services/eventService.js
+++ b/backend/services/eventService.js
@@ -19,6 +19,16 @@ const deleteEvent = async (id) => eventCrud.remove(id);
 const participateEvent = async ({ eventId, userId }) => {
   const event = await eventCrud.findById(eventId);
 
+  const alreadyParticipated = event.commits.some(
+    (commit) => commit.user.toString() === userId.toString()
+  );
+
+  if (alreadyParticipated) {
+    const error = new Error('User has already participated in this event');
+    error.statusCode = 409;
+    throw error;
+  }
+
   event.commits.push({ user: userId });
   await event.save();
 


### PR DESCRIPTION
## Related Issue

Closes #278

## Problem

`participateEvent` in `eventService.js` pushed a commit entry unconditionally:

```js
event.commits.push({ user: userId });
await event.save();
```

Calling the endpoint multiple times with the same `userId` and `eventId` created duplicate entries in `event.commits`, inflating the displayed participant count for organisers.

## Fix

Added an idempotency guard before the push:

```js
const alreadyParticipated = event.commits.some(
  (commit) => commit.user.toString() === userId.toString()
);

if (alreadyParticipated) {
  const error = new Error('User has already participated in this event');
  error.statusCode = 409;
  throw error;
}
```

The thrown error carries `statusCode = 409`. The global error handler in `error.middleware.js` reads `err.statusCode` (line 22) and forwards it as the HTTP status, so the endpoint returns 409 Conflict on duplicate attempts without any changes to the middleware.

## Files Changed

| File | Change |
|---|---|
| `backend/services/eventService.js` | Add participation duplicate check before `event.commits.push` |

## Testing

- First RSVP for a given user and event: HTTP 200.
- Second RSVP with the same user and event: HTTP 409 Conflict.
- Different user RSVPing for the same event: HTTP 200.

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!