### PR TITLE
fix(events): add pagination to listEvents to prevent unbounded MongoDB queries

### DIFF
--- a/backend/controllers/event.controller.js
+++ b/backend/controllers/event.controller.js
@@ -11,8 +11,11 @@ const {
 // all events details
 async function listEvents(req, res, next) {
     try {
-        const events = await listEventsService();
-        res.json(events);
+        const result = await listEventsService({
+            page: req.query.page,
+            limit: req.query.limit,
+        });
+        res.json(result);
     } catch (err) {
         next(err);
     }

--- a/backend/services/baseService.js
+++ b/backend/services/baseService.js
@@ -36,8 +36,11 @@ const createCrudService = ({
     return result;
   };
 
-  const list = async ({ filter = {}, populate, sort } = {}) => {
-    return await applyQueryOptions(model.find(filter), { populate, sort });
+  const list = async ({ filter = {}, populate, sort, skip, limit } = {}) => {
+    let query = applyQueryOptions(model.find(filter), { populate, sort });
+    if (typeof skip === 'number') query = query.skip(skip);
+    if (typeof limit === 'number') query = query.limit(limit);
+    return await query;
   };
 
   const findById = async (id, { populate } = {}) => {

--- a/backend/services/eventService.js
+++ b/backend/services/eventService.js
@@ -8,7 +8,18 @@ const eventCrud = createCrudService({
   defaultSort: { schedule: -1 },
 });
 
-const listEvents = async () => eventCrud.list();
+const listEvents = async ({ page = 1, limit = 20 } = {}) => {
+  const safeLimit = Math.min(Math.max(1, Number(limit)), 100);
+  const safePage  = Math.max(1, Number(page));
+  const skip      = (safePage - 1) * safeLimit;
+
+  const [events, total] = await Promise.all([
+    eventCrud.list({ skip, limit: safeLimit }),
+    eventCrud.model.countDocuments(),
+  ]);
+
+  return { events, total, page: safePage, limit: safeLimit, totalPages: Math.ceil(total / safeLimit) };
+};
 
 const addEvent = async (payload) => eventCrud.create(payload);
 


### PR DESCRIPTION
## Related Issue

Closes #281

## Problem

`listEvents` called `eventCrud.list()` with no filter, sort limit, or pagination:

```js
const listEvents = async () => eventCrud.list();
```

`eventCrud.list()` maps to `model.find({})` with no `limit()`. As the events collection grows, every call to `GET /events` fetches the full collection in one round-trip, eventually exhausting available memory and causing response timeouts.

## Fix

Three coordinated changes:

### 1. `baseService.js` — add optional `skip` and `limit` to `list`

```js
const list = async ({ filter = {}, populate, sort, skip, limit } = {}) => {
  let query = applyQueryOptions(model.find(filter), { populate, sort });
  if (typeof skip  === 'number') query = query.skip(skip);
  if (typeof limit === 'number') query = query.limit(limit);
  return await query;
};
```

Both parameters are optional (no defaults), so every other caller of `eventCrud.list()` or any other CRUD service is completely unaffected.

### 2. `eventService.js` — paginate `listEvents`

```js
const listEvents = async ({ page = 1, limit = 20 } = {}) => {
  const safeLimit = Math.min(Math.max(1, Number(limit)), 100);
  const safePage  = Math.max(1, Number(page));
  const skip      = (safePage - 1) * safeLimit;

  const [events, total] = await Promise.all([
    eventCrud.list({ skip, limit: safeLimit }),
    eventCrud.model.countDocuments(),
  ]);

  return { events, total, page: safePage, limit: safeLimit, totalPages: Math.ceil(total / safeLimit) };
};
```

`Promise.all` fetches the page and the total count in parallel, keeping the round-trip cost to one extra query.

### 3. `event.controller.js` — forward query parameters

```js
const result = await listEventsService({
    page: req.query.page,
    limit: req.query.limit,
});
res.json(result);
```

## Response Shape Change

| Before | After |
|---|---|
| Raw array of events | `{ events, total, page, limit, totalPages }` |

## Files Changed

| File | Change |
|---|---|
| `backend/services/baseService.js` | Add optional `skip` and `limit` to `list` |
| `backend/services/eventService.js` | Replace plain `eventCrud.list()` with paginated implementation |
| `backend/controllers/event.controller.js` | Forward `req.query.page` and `req.query.limit` to service |

## Testing

- `GET /events` returns first 20 events with pagination metadata.
- `GET /events?page=2&limit=10` returns events 11-20.
- `limit=500` is clamped to `100`.

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!